### PR TITLE
Adjust YouTube service to use user handles

### DIFF
--- a/MixItUp.Base/Model/User/Platform/YouTubeUserPlatformV2Model.cs
+++ b/MixItUp.Base/Model/User/Platform/YouTubeUserPlatformV2Model.cs
@@ -88,8 +88,8 @@ namespace MixItUp.Base.Model.User.Platform
         public void SetMessageProperties(LiveChatMessage message)
         {
             this.ID = message.AuthorDetails.ChannelId;
-            this.Username = message.AuthorDetails.DisplayName;
-            this.DisplayName = message.AuthorDetails.DisplayName;
+            this.Username = message.AuthorDetails.DisplayName?.TrimStart('@');
+            this.DisplayName = message.AuthorDetails.DisplayName?.TrimStart('@');
             this.AvatarLink = message.AuthorDetails.ProfileImageUrl;
             this.YouTubeURL = message.AuthorDetails.ChannelUrl;
 
@@ -133,10 +133,10 @@ namespace MixItUp.Base.Model.User.Platform
         private void SetChannelProperties(Channel channel)
         {
             this.ID = channel.Id;
-            this.Username = channel.Snippet.Title;
-            this.DisplayName = channel.Snippet.Title;
+            this.Username = channel.Snippet.CustomUrl?.TrimStart('@');
+            this.DisplayName = channel.Snippet.CustomUrl?.TrimStart('@');
             this.AvatarLink = channel.Snippet.Thumbnails.Default__.Url;
-            this.YouTubeURL = "https://www.youtube.com/channel/" + channel.Id;
+            this.YouTubeURL = "https://www.youtube.com/" + (channel.Snippet.CustomUrl ?? ("channel/" + channel.Id));
             this.AccountDate = YouTubeSession.GetYouTubeDateTime(channel.Snippet.PublishedAtRaw);
         }
     }

--- a/MixItUp.Base/Services/YouTube/New/YouTubeSession.cs
+++ b/MixItUp.Base/Services/YouTube/New/YouTubeSession.cs
@@ -140,11 +140,11 @@ namespace MixItUp.Base.Services.YouTube.New
             }
 
             this.StreamerID = this.StreamerModel?.Id;
-            this.StreamerUsername = this.StreamerModel?.Snippet?.Title;
+            this.StreamerUsername = this.StreamerModel?.Snippet?.CustomUrl?.TrimStart('@');
             this.StreamerAvatarURL = this.StreamerModel?.Snippet?.Thumbnails?.Medium?.Url;
 
             this.ChannelID = this.StreamerModel?.Id;
-            this.ChannelLink = this.StreamerModel?.Snippet?.CustomUrl;
+            this.ChannelLink = "https://www.youtube.com/" + this.StreamerModel?.Snippet?.CustomUrl;
 
             this.Streamer = await ServiceManager.Get<UserService>().GetUserByPlatform(StreamingPlatformTypeEnum.YouTube, platformID: this.StreamerID);
             if (this.Streamer == null)
@@ -199,7 +199,7 @@ namespace MixItUp.Base.Services.YouTube.New
             }
 
             this.BotID = this.BotModel?.Id;
-            this.BotUsername = this.BotModel?.Snippet?.Title;
+            this.BotUsername = this.BotModel?.Snippet?.CustomUrl?.TrimStart('@');
             this.BotAvatarURL = this.BotModel?.Snippet?.Thumbnails?.Medium?.Url;
 
             this.Bot = await ServiceManager.Get<UserService>().GetUserByPlatform(StreamingPlatformTypeEnum.YouTube, platformID: this.BotID);


### PR DESCRIPTION
Adjust YouTube service to use user handles instead of their "Title" due to YT chat changes.

 To follow standards as other platforms, we're also stripping the @ from their handles and storing that in the database ("mixitupapp" instead of "@mixitupapp" is saved)

https://support.google.com/youtube/answer/2657968