### PR TITLE
Feat/missingfilescheck

### DIFF
--- a/MixItUp.Base/Model/Settings/SettingsV3Model.cs
+++ b/MixItUp.Base/Model/Settings/SettingsV3Model.cs
@@ -1046,6 +1046,16 @@ namespace MixItUp.Base.Model.Settings
             await ServiceManager.Get<IDatabaseService>().CompressDb(this.DatabaseFilePath);
         }
 
+        public async Task SaveMissingFilesCheckCommand(CommandModelBase command)
+        {
+            if (command == null) return;
+            this.Commands.ManualValueChanged(command.ID);
+            await ServiceManager.Get<IDatabaseService>().BulkWrite(
+                this.DatabaseFilePath,
+                "REPLACE INTO Commands(ID, TypeID, Data) VALUES($ID, $TypeID, $Data)",
+                new List<Dictionary<string, object>>() { new Dictionary<string, object>() { { "$ID", command.ID.ToString() }, { "$TypeID", (int)command.Type }, { "$Data", JSONSerializerHelper.SerializeToString(command) } } });
+        }
+
         public async Task<IEnumerable<UserV2Model>> LoadUserV2Data(string query, Dictionary<string, object> parameters)
         {
             List<UserV2Model> results = new List<UserV2Model>();

--- a/MixItUp.Base/Resources.Designer.cs
+++ b/MixItUp.Base/Resources.Designer.cs
@@ -331,6 +331,15 @@ namespace MixItUp.Base {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Action Type.
+        /// </summary>
+        public static string ActionType {
+            get {
+                return ResourceManager.GetString("ActionType", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Activate Trigger.
         /// </summary>
         public static string ActivateTrigger {
@@ -14009,6 +14018,42 @@ namespace MixItUp.Base {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Missing Files Check.
+        /// </summary>
+        public static string MissingFilesCheck {
+            get {
+                return ResourceManager.GetString("MissingFilesCheck", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Check missing file paths in commands:.
+        /// </summary>
+        public static string MissingFilesCheckDescription {
+            get {
+                return ResourceManager.GetString("MissingFilesCheckDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Before you continue, we recommend creating a backup of your profile using the Backup Settings button above. Continue?.
+        /// </summary>
+        public static string MissingFilesCheckDialog {
+            get {
+                return ResourceManager.GetString("MissingFilesCheckDialog", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Check Paths.
+        /// </summary>
+        public static string MissingFilesCheckPaths {
+            get {
+                return ResourceManager.GetString("MissingFilesCheckPaths", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Missing Text.
         /// </summary>
         public static string MissingTextHintWarning {
@@ -19056,6 +19101,24 @@ namespace MixItUp.Base {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Replace.
+        /// </summary>
+        public static string Replace {
+            get {
+                return ResourceManager.GetString("Replace", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Replace All.
+        /// </summary>
+        public static string ReplaceAll {
+            get {
+                return ResourceManager.GetString("ReplaceAll", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Replaced.
         /// </summary>
         public static string Replaced {
@@ -19209,6 +19272,15 @@ namespace MixItUp.Base {
         public static string ReRunNewUserWizard {
             get {
                 return ResourceManager.GetString("ReRunNewUserWizard", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Rescan.
+        /// </summary>
+        public static string Rescan {
+            get {
+                return ResourceManager.GetString("Rescan", resourceCulture);
             }
         }
         
@@ -20343,6 +20415,15 @@ namespace MixItUp.Base {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Search Folder.
+        /// </summary>
+        public static string SearchFolder {
+            get {
+                return ResourceManager.GetString("SearchFolder", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Search Text.
         /// </summary>
         public static string SearchText {
@@ -20496,6 +20577,15 @@ namespace MixItUp.Base {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Select a path.
+        /// </summary>
+        public static string SelectAPath {
+            get {
+                return ResourceManager.GetString("SelectAPath", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Selected Campaign.
         /// </summary>
         public static string SelectedCampaign {
@@ -20510,6 +20600,15 @@ namespace MixItUp.Base {
         public static string SelectedFundraiser {
             get {
                 return ResourceManager.GetString("SelectedFundraiser", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Selected Path:.
+        /// </summary>
+        public static string SelectedPath {
+            get {
+                return ResourceManager.GetString("SelectedPath", resourceCulture);
             }
         }
         
@@ -21119,6 +21218,15 @@ namespace MixItUp.Base {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Show all paths.
+        /// </summary>
+        public static string ShowAllPaths {
+            get {
+                return ResourceManager.GetString("ShowAllPaths", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Show BetterTTV Emotes (Requires Restart).
         /// </summary>
         public static string ShowBetterTTVEmotes {
@@ -21277,6 +21385,15 @@ namespace MixItUp.Base {
         public static string ShowMessageTimestamp {
             get {
                 return ResourceManager.GetString("ShowMessageTimestamp", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Show missing paths.
+        /// </summary>
+        public static string ShowMissingPaths {
+            get {
+                return ResourceManager.GetString("ShowMissingPaths", resourceCulture);
             }
         }
         
@@ -21457,6 +21574,24 @@ namespace MixItUp.Base {
         public static string ShowUserJoinLeave {
             get {
                 return ResourceManager.GetString("ShowUserJoinLeave", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Show valid paths.
+        /// </summary>
+        public static string ShowValidPaths {
+            get {
+                return ResourceManager.GetString("ShowValidPaths", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Show warning paths.
+        /// </summary>
+        public static string ShowWarningPaths {
+            get {
+                return ResourceManager.GetString("ShowWarningPaths", resourceCulture);
             }
         }
         
@@ -22090,6 +22225,15 @@ namespace MixItUp.Base {
         public static string Statistics {
             get {
                 return ResourceManager.GetString("Statistics", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Status.
+        /// </summary>
+        public static string Status {
+            get {
+                return ResourceManager.GetString("Status", resourceCulture);
             }
         }
         

--- a/MixItUp.Base/Resources.resx
+++ b/MixItUp.Base/Resources.resx
@@ -11088,4 +11088,52 @@ We have detected that you have more than 1 Overlay Endpoint created, meaning the
   <data name="TwitchClipDurationLimits" xml:space="preserve">
     <value>Clip duration must be between 5 and 60 seconds.</value>
   </data>
+  <data name="MissingFilesCheckDialog" xml:space="preserve">
+    <value>Before you continue, we recommend creating a backup of your profile using the Backup Settings button above. Continue?</value>
+  </data>
+  <data name="MissingFilesCheckDescription" xml:space="preserve">
+    <value>Check missing file paths in commands:</value>
+  </data>
+  <data name="MissingFilesCheckPaths" xml:space="preserve">
+    <value>Check Paths</value>
+  </data>
+  <data name="MissingFilesCheck" xml:space="preserve">
+    <value>Missing Files Check</value>
+  </data>
+  <data name="ShowAllPaths" xml:space="preserve">
+    <value>Show all paths</value>
+  </data>
+  <data name="ShowValidPaths" xml:space="preserve">
+    <value>Show valid paths</value>
+  </data>
+  <data name="ShowWarningPaths" xml:space="preserve">
+    <value>Show warning paths</value>
+  </data>
+  <data name="ShowMissingPaths" xml:space="preserve">
+    <value>Show missing paths</value>
+  </data>
+  <data name="Rescan" xml:space="preserve">
+    <value>Rescan</value>
+  </data>
+  <data name="Status" xml:space="preserve">
+    <value>Status</value>
+  </data>
+  <data name="ActionType" xml:space="preserve">
+    <value>Action Type</value>
+  </data>
+  <data name="SelectedPath" xml:space="preserve">
+    <value>Selected Path:</value>
+  </data>
+  <data name="SelectAPath" xml:space="preserve">
+    <value>Select a path</value>
+  </data>
+  <data name="SearchFolder" xml:space="preserve">
+    <value>Search Folder</value>
+  </data>
+  <data name="Replace" xml:space="preserve">
+    <value>Replace</value>
+  </data>
+  <data name="ReplaceAll" xml:space="preserve">
+    <value>Replace All</value>
+  </data>
 </root>

--- a/MixItUp.Base/Services/MissingFilesCheckService.cs
+++ b/MixItUp.Base/Services/MissingFilesCheckService.cs
@@ -3,9 +3,11 @@ using MixItUp.Base.Model.Commands;
 using MixItUp.Base.Model.Overlay;
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using System.IO;
 using System.Linq;
 using MixItUp.Base.Util;
+using MixItUp.Base;
 
 namespace MixItUp.Base.Services
 {
@@ -223,6 +225,16 @@ namespace MixItUp.Base.Services
                 reference.Validate();
                 references.Add(reference);
             }
+        }
+
+        public async Task SaveCommand(CommandModelBase command)
+        {
+            if (command == null) return;
+            ChannelSession.Settings.Commands.ManualValueChanged(command.ID);
+            await ServiceManager.Get<IDatabaseService>().BulkWrite(
+                ChannelSession.Settings.DatabaseFilePath,
+                "REPLACE INTO Commands(ID, TypeID, Data) VALUES($ID, $TypeID, $Data)",
+                new List<Dictionary<string, object>>() { new Dictionary<string, object>() { { "$ID", command.ID.ToString() }, { "$TypeID", (int)command.Type }, { "$Data", JSONSerializerHelper.SerializeToString(command) } } });
         }
     }
 }

--- a/MixItUp.Base/Services/MissingFilesCheckService.cs
+++ b/MixItUp.Base/Services/MissingFilesCheckService.cs
@@ -19,9 +19,7 @@ namespace MixItUp.Base.Services
     public class MissingFilesCheckReference
     {
         public CommandModelBase Command { get; set; }
-        public ActionModelBase Action { get; set; }
         public string ActionTypeName { get; set; }
-        public string PropertyName { get; set; }
         public string FilePath { get; set; }
         public MissingFilesCheckStatus Status { get; set; }
         public Action<string> UpdatePath { get; set; }
@@ -101,7 +99,7 @@ namespace MixItUp.Base.Services
         {
             List<MissingFilesCheckReference> references = new List<MissingFilesCheckReference>();
 
-            foreach (CommandModelBase command in ServiceManager.Get<CommandService>().AllCommands)
+            foreach (CommandModelBase command in ChannelSession.Settings.Commands.Values)
             {
                 ScanActions(command, command.Actions, references);
             }
@@ -141,82 +139,81 @@ namespace MixItUp.Base.Services
                 switch (action)
                 {
                     case SoundActionModel soundAction:
-                        AddReference(references, command, action, "Sound", "FilePath", soundAction.FilePath, p => soundAction.FilePath = p);
+                        AddReference(references, command, "Sound", soundAction.FilePath, p => soundAction.FilePath = p);
                         break;
 
                     case FileActionModel fileAction:
-                        AddReference(references, command, action, "File", "FilePath", fileAction.FilePath, p => fileAction.FilePath = p);
+                        AddReference(references, command, "File", fileAction.FilePath, p => fileAction.FilePath = p);
                         break;
 
                     case ExternalProgramActionModel externalAction:
-                        AddReference(references, command, action, "External Program", "FilePath", externalAction.FilePath, p => externalAction.FilePath = p);
+                        AddReference(references, command, "External Program", externalAction.FilePath, p => externalAction.FilePath = p);
                         break;
 
                     case StreamingSoftwareActionModel streamingAction:
-                        AddReference(references, command, action, "Streaming Software", "SourceURL", streamingAction.SourceURL, p => streamingAction.SourceURL = p);
-                        AddReference(references, command, action, "Streaming Software", "SourceTextFilePath", streamingAction.SourceTextFilePath, p => streamingAction.SourceTextFilePath = p);
+                        AddReference(references, command, "Streaming Software", streamingAction.SourceURL, p => streamingAction.SourceURL = p);
+                        AddReference(references, command, "Streaming Software", streamingAction.SourceTextFilePath, p => streamingAction.SourceTextFilePath = p);
                         break;
 
                     case MusicPlayerActionModel musicAction:
-                        AddReference(references, command, action, "Music Player", "FolderPath", musicAction.FolderPath, p => musicAction.FolderPath = p);
+                        AddReference(references, command, "Music Player", musicAction.FolderPath, p => musicAction.FolderPath = p);
                         break;
 
                     case DiscordActionModel discordAction:
                         if (discordAction.ActionType == DiscordActionTypeEnum.SendMessage)
                         {
-                            AddReference(references, command, action, "Discord", "FilePath", discordAction.FilePath, p => discordAction.FilePath = p);
+                            AddReference(references, command, "Discord", discordAction.FilePath, p => discordAction.FilePath = p);
                         }
                         break;
 
                     case VTSPogActionModel vtsPogAction:
                         if (vtsPogAction.ActionType == VTSPogActionTypeEnum.PlayAudioFile)
                         {
-                            AddReference(references, command, action, "VTS Pog", "AudioFilePath", vtsPogAction.AudioFilePath, p => vtsPogAction.AudioFilePath = p);
+                            AddReference(references, command, "VTS Pog", vtsPogAction.AudioFilePath, p => vtsPogAction.AudioFilePath = p);
                         }
                         break;
 
                     case OverlayActionModel overlayAction:
                         if (overlayAction.OverlayItemV3 != null)
                         {
-                            ScanOverlayItem(command, action, overlayAction.OverlayItemV3, references);
+                            ScanOverlayItem(command, overlayAction.OverlayItemV3, references);
                         }
                         break;
 
                     case GroupActionModel groupAction:
+                        // This handles Group, Conditional, Random, and Repeat actions (they all inherit from GroupActionModel)
                         ScanActions(command, groupAction.Actions, references);
                         break;
                 }
             }
         }
 
-        private void ScanOverlayItem(CommandModelBase command, ActionModelBase action, OverlayItemV3ModelBase overlayItem, List<MissingFilesCheckReference> references)
+        private void ScanOverlayItem(CommandModelBase command, OverlayItemV3ModelBase overlayItem, List<MissingFilesCheckReference> references)
         {
             switch (overlayItem)
             {
                 case OverlayVideoV3Model videoItem:
-                    AddReference(references, command, action, "Overlay Video", "FilePath", videoItem.FilePath, p => videoItem.FilePath = p);
+                    AddReference(references, command, "Overlay Video", videoItem.FilePath, p => videoItem.FilePath = p);
                     break;
 
                 case OverlaySoundV3Model soundItem:
-                    AddReference(references, command, action, "Overlay Sound", "FilePath", soundItem.FilePath, p => soundItem.FilePath = p);
+                    AddReference(references, command, "Overlay Sound", soundItem.FilePath, p => soundItem.FilePath = p);
                     break;
 
                 case OverlayImageV3Model imageItem:
-                    AddReference(references, command, action, "Overlay Image", "FilePath", imageItem.FilePath, p => imageItem.FilePath = p);
+                    AddReference(references, command, "Overlay Image", imageItem.FilePath, p => imageItem.FilePath = p);
                     break;
             }
         }
 
-        private void AddReference(List<MissingFilesCheckReference> references, CommandModelBase command, ActionModelBase action, string actionTypeName, string propertyName, string filePath, Action<string> updateAction)
+        private void AddReference(List<MissingFilesCheckReference> references, CommandModelBase command, string actionTypeName, string filePath, Action<string> updateAction)
         {
             if (!string.IsNullOrEmpty(filePath))
             {
                 var reference = new MissingFilesCheckReference
                 {
                     Command = command,
-                    Action = action,
                     ActionTypeName = actionTypeName,
-                    PropertyName = propertyName,
                     FilePath = filePath,
                     UpdatePath = updateAction
                 };

--- a/MixItUp.Base/Services/MissingFilesCheckService.cs
+++ b/MixItUp.Base/Services/MissingFilesCheckService.cs
@@ -3,11 +3,9 @@ using MixItUp.Base.Model.Commands;
 using MixItUp.Base.Model.Overlay;
 using System;
 using System.Collections.Generic;
-using System.Threading.Tasks;
 using System.IO;
 using System.Linq;
 using MixItUp.Base.Util;
-using MixItUp.Base;
 
 namespace MixItUp.Base.Services
 {
@@ -226,15 +224,6 @@ namespace MixItUp.Base.Services
                 references.Add(reference);
             }
         }
-
-        public async Task SaveCommand(CommandModelBase command)
-        {
-            if (command == null) return;
-            ChannelSession.Settings.Commands.ManualValueChanged(command.ID);
-            await ServiceManager.Get<IDatabaseService>().BulkWrite(
-                ChannelSession.Settings.DatabaseFilePath,
-                "REPLACE INTO Commands(ID, TypeID, Data) VALUES($ID, $TypeID, $Data)",
-                new List<Dictionary<string, object>>() { new Dictionary<string, object>() { { "$ID", command.ID.ToString() }, { "$TypeID", (int)command.Type }, { "$Data", JSONSerializerHelper.SerializeToString(command) } } });
-        }
+ 
     }
 }

--- a/MixItUp.Base/Services/MissingFilesCheckService.cs
+++ b/MixItUp.Base/Services/MissingFilesCheckService.cs
@@ -24,7 +24,7 @@ namespace MixItUp.Base.Services
         public MissingFilesCheckStatus Status { get; set; }
         public Action<string> UpdatePath { get; set; }
 
-        public string CommandName => Command?.Name ?? "Unknown";
+        public string CommandName => Command?.Name ?? MixItUp.Base.Resources.Unknown;
 
         public void Validate()
         {
@@ -139,37 +139,37 @@ namespace MixItUp.Base.Services
                 switch (action)
                 {
                     case SoundActionModel soundAction:
-                        AddReference(references, command, "Sound", soundAction.FilePath, p => soundAction.FilePath = p);
+                        AddReference(references, command, MixItUp.Base.Resources.Sound, soundAction.FilePath, p => soundAction.FilePath = p);
                         break;
 
                     case FileActionModel fileAction:
-                        AddReference(references, command, "File", fileAction.FilePath, p => fileAction.FilePath = p);
+                        AddReference(references, command, MixItUp.Base.Resources.FileReadAndWrite, fileAction.FilePath, p => fileAction.FilePath = p);
                         break;
 
                     case ExternalProgramActionModel externalAction:
-                        AddReference(references, command, "External Program", externalAction.FilePath, p => externalAction.FilePath = p);
+                        AddReference(references, command, MixItUp.Base.Resources.ExternalProgram, externalAction.FilePath, p => externalAction.FilePath = p);
                         break;
 
                     case StreamingSoftwareActionModel streamingAction:
-                        AddReference(references, command, "Streaming Software", streamingAction.SourceURL, p => streamingAction.SourceURL = p);
-                        AddReference(references, command, "Streaming Software", streamingAction.SourceTextFilePath, p => streamingAction.SourceTextFilePath = p);
+                        AddReference(references, command, MixItUp.Base.Resources.StreamingSoftware, streamingAction.SourceURL, p => streamingAction.SourceURL = p);
+                        AddReference(references, command, MixItUp.Base.Resources.StreamingSoftware, streamingAction.SourceTextFilePath, p => streamingAction.SourceTextFilePath = p);
                         break;
 
                     case MusicPlayerActionModel musicAction:
-                        AddReference(references, command, "Music Player", musicAction.FolderPath, p => musicAction.FolderPath = p);
+                        AddReference(references, command, MixItUp.Base.Resources.MusicPlayer, musicAction.FolderPath, p => musicAction.FolderPath = p);
                         break;
 
                     case DiscordActionModel discordAction:
                         if (discordAction.ActionType == DiscordActionTypeEnum.SendMessage)
                         {
-                            AddReference(references, command, "Discord", discordAction.FilePath, p => discordAction.FilePath = p);
+                            AddReference(references, command, MixItUp.Base.Resources.Discord, discordAction.FilePath, p => discordAction.FilePath = p);
                         }
                         break;
 
                     case VTSPogActionModel vtsPogAction:
                         if (vtsPogAction.ActionType == VTSPogActionTypeEnum.PlayAudioFile)
                         {
-                            AddReference(references, command, "VTS Pog", vtsPogAction.AudioFilePath, p => vtsPogAction.AudioFilePath = p);
+                            AddReference(references, command, MixItUp.Base.Resources.VTSPog, vtsPogAction.AudioFilePath, p => vtsPogAction.AudioFilePath = p);
                         }
                         break;
 
@@ -181,9 +181,11 @@ namespace MixItUp.Base.Services
                         break;
 
                     case GroupActionModel groupAction:
-                        // This handles Group, Conditional, Random, and Repeat actions (they all inherit from GroupActionModel)
+                        // Group, Conditional, Random, and Repeat actions (they all inherit from GroupActionModel)
                         ScanActions(command, groupAction.Actions, references);
                         break;
+
+                    // to do: find a better way instead of hardcoding each action model. 
                 }
             }
         }
@@ -193,15 +195,15 @@ namespace MixItUp.Base.Services
             switch (overlayItem)
             {
                 case OverlayVideoV3Model videoItem:
-                    AddReference(references, command, "Overlay Video", videoItem.FilePath, p => videoItem.FilePath = p);
+                    AddReference(references, command, MixItUp.Base.Resources.Overlay, videoItem.FilePath, p => videoItem.FilePath = p);
                     break;
 
                 case OverlaySoundV3Model soundItem:
-                    AddReference(references, command, "Overlay Sound", soundItem.FilePath, p => soundItem.FilePath = p);
+                    AddReference(references, command, MixItUp.Base.Resources.Overlay, soundItem.FilePath, p => soundItem.FilePath = p);
                     break;
 
                 case OverlayImageV3Model imageItem:
-                    AddReference(references, command, "Overlay Image", imageItem.FilePath, p => imageItem.FilePath = p);
+                    AddReference(references, command, MixItUp.Base.Resources.Overlay, imageItem.FilePath, p => imageItem.FilePath = p);
                     break;
             }
         }

--- a/MixItUp.Base/Services/MissingFilesCheckService.cs
+++ b/MixItUp.Base/Services/MissingFilesCheckService.cs
@@ -1,0 +1,228 @@
+using MixItUp.Base.Model.Actions;
+using MixItUp.Base.Model.Commands;
+using MixItUp.Base.Model.Overlay;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using MixItUp.Base.Util;
+
+namespace MixItUp.Base.Services
+{
+    public enum MissingFilesCheckStatus
+    {
+        Valid,
+        Invalid,
+        Warning
+    }
+
+    public class MissingFilesCheckReference
+    {
+        public CommandModelBase Command { get; set; }
+        public ActionModelBase Action { get; set; }
+        public string ActionTypeName { get; set; }
+        public string PropertyName { get; set; }
+        public string FilePath { get; set; }
+        public MissingFilesCheckStatus Status { get; set; }
+        public Action<string> UpdatePath { get; set; }
+
+        public string CommandName => Command?.Name ?? "Unknown";
+
+        public void Validate()
+        {
+            if (string.IsNullOrWhiteSpace(FilePath))
+            {
+                Status = MissingFilesCheckStatus.Invalid;
+                return;
+            }
+
+            string path = FilePath;
+            if (path.Contains("|"))
+            {
+                string[] paths = path.Split('|');
+                foreach (string p in paths)
+                {
+                    var result = GetPathStatus(p.Trim());
+                    if (result == MissingFilesCheckStatus.Invalid)
+                    {
+                        Status = MissingFilesCheckStatus.Invalid;
+                        return;
+                    }
+                    if (result == MissingFilesCheckStatus.Warning)
+                    {
+                        Status = MissingFilesCheckStatus.Warning;
+                    }
+                }
+                if (Status != MissingFilesCheckStatus.Warning)
+                {
+                    Status = MissingFilesCheckStatus.Valid;
+                }
+            }
+            else
+            {
+                Status = GetPathStatus(path);
+            }
+        }
+
+        private MissingFilesCheckStatus GetPathStatus(string path)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                return MissingFilesCheckStatus.Invalid;
+            }
+
+            if (path.Contains("$"))
+            {
+                return MissingFilesCheckStatus.Warning;
+            }
+
+            if (ServiceManager.Get<IFileService>().IsURLPath(path))
+            {
+                return MissingFilesCheckStatus.Valid;
+            }
+
+            if (Directory.Exists(path))
+            {
+                return MissingFilesCheckStatus.Valid;
+            }
+
+            if (File.Exists(path))
+            {
+                return MissingFilesCheckStatus.Valid;
+            }
+
+            return MissingFilesCheckStatus.Invalid;
+        }
+    }
+
+    public class MissingFilesCheckService
+    {
+        public List<MissingFilesCheckReference> GetAllFilePaths()
+        {
+            List<MissingFilesCheckReference> references = new List<MissingFilesCheckReference>();
+
+            foreach (CommandModelBase command in ServiceManager.Get<CommandService>().AllCommands)
+            {
+                ScanActions(command, command.Actions, references);
+            }
+
+            return references;
+        }
+
+        public Dictionary<string, string> GetFileLookup(string folderPath)
+        {
+            Dictionary<string, string> fileLookup = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            if (Directory.Exists(folderPath))
+            {
+                try
+                {
+                    string[] foundFiles = Directory.GetFiles(folderPath, "*.*", SearchOption.AllDirectories);
+                    foreach (string file in foundFiles)
+                    {
+                        string fileName = Path.GetFileName(file);
+                        if (!fileLookup.ContainsKey(fileName))
+                        {
+                            fileLookup[fileName] = file;
+                        }
+                    }
+                }
+                catch (Exception ex) 
+                { 
+                    Logger.Log(ex); 
+                }
+            }
+            return fileLookup;
+        }
+
+        private void ScanActions(CommandModelBase command, IEnumerable<ActionModelBase> actions, List<MissingFilesCheckReference> references)
+        {
+            foreach (ActionModelBase action in actions)
+            {
+                switch (action)
+                {
+                    case SoundActionModel soundAction:
+                        AddReference(references, command, action, "Sound", "FilePath", soundAction.FilePath, p => soundAction.FilePath = p);
+                        break;
+
+                    case FileActionModel fileAction:
+                        AddReference(references, command, action, "File", "FilePath", fileAction.FilePath, p => fileAction.FilePath = p);
+                        break;
+
+                    case ExternalProgramActionModel externalAction:
+                        AddReference(references, command, action, "External Program", "FilePath", externalAction.FilePath, p => externalAction.FilePath = p);
+                        break;
+
+                    case StreamingSoftwareActionModel streamingAction:
+                        AddReference(references, command, action, "Streaming Software", "SourceURL", streamingAction.SourceURL, p => streamingAction.SourceURL = p);
+                        AddReference(references, command, action, "Streaming Software", "SourceTextFilePath", streamingAction.SourceTextFilePath, p => streamingAction.SourceTextFilePath = p);
+                        break;
+
+                    case MusicPlayerActionModel musicAction:
+                        AddReference(references, command, action, "Music Player", "FolderPath", musicAction.FolderPath, p => musicAction.FolderPath = p);
+                        break;
+
+                    case DiscordActionModel discordAction:
+                        if (discordAction.ActionType == DiscordActionTypeEnum.SendMessage)
+                        {
+                            AddReference(references, command, action, "Discord", "FilePath", discordAction.FilePath, p => discordAction.FilePath = p);
+                        }
+                        break;
+
+                    case VTSPogActionModel vtsPogAction:
+                        if (vtsPogAction.ActionType == VTSPogActionTypeEnum.PlayAudioFile)
+                        {
+                            AddReference(references, command, action, "VTS Pog", "AudioFilePath", vtsPogAction.AudioFilePath, p => vtsPogAction.AudioFilePath = p);
+                        }
+                        break;
+
+                    case OverlayActionModel overlayAction:
+                        if (overlayAction.OverlayItemV3 != null)
+                        {
+                            ScanOverlayItem(command, action, overlayAction.OverlayItemV3, references);
+                        }
+                        break;
+
+                    case GroupActionModel groupAction:
+                        ScanActions(command, groupAction.Actions, references);
+                        break;
+                }
+            }
+        }
+
+        private void ScanOverlayItem(CommandModelBase command, ActionModelBase action, OverlayItemV3ModelBase overlayItem, List<MissingFilesCheckReference> references)
+        {
+            switch (overlayItem)
+            {
+                case OverlayVideoV3Model videoItem:
+                    AddReference(references, command, action, "Overlay Video", "FilePath", videoItem.FilePath, p => videoItem.FilePath = p);
+                    break;
+
+                case OverlaySoundV3Model soundItem:
+                    AddReference(references, command, action, "Overlay Sound", "FilePath", soundItem.FilePath, p => soundItem.FilePath = p);
+                    break;
+
+                case OverlayImageV3Model imageItem:
+                    AddReference(references, command, action, "Overlay Image", "FilePath", imageItem.FilePath, p => imageItem.FilePath = p);
+                    break;
+            }
+        }
+
+        private void AddReference(List<MissingFilesCheckReference> references, CommandModelBase command, ActionModelBase action, string actionTypeName, string propertyName, string filePath, Action<string> updateAction)
+        {
+            if (!string.IsNullOrEmpty(filePath))
+            {
+                var reference = new MissingFilesCheckReference
+                {
+                    Command = command,
+                    Action = action,
+                    ActionTypeName = actionTypeName,
+                    PropertyName = propertyName,
+                    FilePath = filePath,
+                    UpdatePath = updateAction
+                };
+                reference.Validate();
+                references.Add(reference);
+            }
+        }
+    }
+}

--- a/MixItUp.Base/ViewModel/MissingFilesCheck/MissingFilesCheckWindowViewModel.cs
+++ b/MixItUp.Base/ViewModel/MissingFilesCheck/MissingFilesCheckWindowViewModel.cs
@@ -9,6 +9,7 @@ using System.IO;
 using MixItUp.Base.Util;
 using System.Threading.Tasks;
 using MixItUp.Base.Model.Commands;
+using MixItUp.Base;
 
 namespace MixItUp.Base.ViewModel.MissingFilesCheck
 {
@@ -30,7 +31,7 @@ namespace MixItUp.Base.ViewModel.MissingFilesCheck
                 NotifyPropertyChanged();
                 NotifyPropertyChanged(nameof(Status));
                 NotifyPropertyChanged(nameof(IsValid));
-                _ = AsyncRunner.RunAsync(() => new MissingFilesCheckService().SaveCommand(Reference.Command));
+                _ = AsyncRunner.RunAsync(() => ChannelSession.Settings.SaveMissingFilesCheckCommand(Reference.Command));
             }
         }
 

--- a/MixItUp.Base/ViewModel/MissingFilesCheck/MissingFilesCheckWindowViewModel.cs
+++ b/MixItUp.Base/ViewModel/MissingFilesCheck/MissingFilesCheckWindowViewModel.cs
@@ -1,0 +1,258 @@
+using MixItUp.Base.Services;
+using MixItUp.Base.ViewModels;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Windows.Input;
+using System.IO;
+
+namespace MixItUp.Base.ViewModel.MissingFilesCheck
+{
+    public class MissingFilesCheckItemViewModel : UIViewModelBase
+    {
+        public MissingFilesCheckReference Reference { get; private set; }
+
+        public string CommandName => Reference.CommandName;
+        public string ActionType => Reference.ActionTypeName;
+
+        public string FilePath
+        {
+            get { return Reference.FilePath; }
+            set
+            {
+                Reference.FilePath = value;
+                Reference.UpdatePath(value);
+                Reference.Validate();
+                NotifyPropertyChanged();
+                NotifyPropertyChanged(nameof(Status));
+                NotifyPropertyChanged(nameof(IsValid));
+            }
+        }
+
+        public MissingFilesCheckStatus Status => Reference.Status;
+        public bool IsValid => Status == MissingFilesCheckStatus.Valid;
+
+        public MissingFilesCheckItemViewModel(MissingFilesCheckReference reference)
+        {
+            Reference = reference;
+        }
+    }
+
+    public class MissingFilesCheckWindowViewModel : UIViewModelBase
+    {
+        public ObservableCollection<MissingFilesCheckItemViewModel> AllItems { get; set; } = new ObservableCollection<MissingFilesCheckItemViewModel>();
+        public ObservableCollection<MissingFilesCheckItemViewModel> FilteredItems { get; set; } = new ObservableCollection<MissingFilesCheckItemViewModel>();
+
+        public MissingFilesCheckStatus? SelectedFilterStatus
+        {
+            get { return this.selectedFilterStatus; }
+            set
+            {
+                this.selectedFilterStatus = value;
+                NotifyPropertyChanged();
+                NotifyPropertyChanged(nameof(SelectedFilterIndex));
+                ApplyFilter();
+            }
+        }
+        private MissingFilesCheckStatus? selectedFilterStatus = null;
+
+        public int SelectedFilterIndex
+        {
+            get
+            {
+                if (SelectedFilterStatus == null) return 0;
+                if (SelectedFilterStatus == MissingFilesCheckStatus.Valid) return 1;
+                if (SelectedFilterStatus == MissingFilesCheckStatus.Warning) return 2;
+                if (SelectedFilterStatus == MissingFilesCheckStatus.Invalid) return 3;
+                return -1;
+            }
+            set
+            {
+                switch (value)
+                {
+                    case 0: SelectedFilterStatus = null; break;
+                    case 1: SelectedFilterStatus = MissingFilesCheckStatus.Valid; break;
+                    case 2: SelectedFilterStatus = MissingFilesCheckStatus.Warning; break;
+                    case 3: SelectedFilterStatus = MissingFilesCheckStatus.Invalid; break;
+                }
+                NotifyPropertyChanged();
+            }
+        }
+
+        public string SearchText
+        {
+            get { return this.searchText; }
+            set
+            {
+                this.searchText = value;
+                NotifyPropertyChanged();
+            }
+        }
+        private string searchText = string.Empty;
+
+        public string ReplaceText
+        {
+            get { return this.replaceText; }
+            set
+            {
+                this.replaceText = value;
+                NotifyPropertyChanged();
+            }
+        }
+        private string replaceText = string.Empty;
+
+        public MissingFilesCheckItemViewModel SelectedItem
+        {
+            get { return this.selectedItem; }
+            set
+            {
+                this.selectedItem = value;
+                NotifyPropertyChanged();
+                NotifyPropertyChanged(nameof(HasSelectedItem));
+            }
+        }
+        private MissingFilesCheckItemViewModel selectedItem;
+
+        public bool HasSelectedItem => SelectedItem != null;
+
+        public int TotalCount => AllItems.Count;
+        public int InvalidCount => AllItems.Count(i => i.Status == MissingFilesCheckStatus.Invalid);
+        public int WarningCount => AllItems.Count(i => i.Status == MissingFilesCheckStatus.Warning);
+        public int ValidCount => AllItems.Count(i => i.Status == MissingFilesCheckStatus.Valid);
+
+        public ICommand ScanCommand { get; set; }
+        public ICommand ReplaceAllCommand { get; set; }
+        public ICommand BrowseCommand { get; set; }
+        public ICommand LocateMissingFilesCommand { get; set; }
+
+        public MissingFilesCheckWindowViewModel()
+        {
+            ScanCommand = this.CreateCommand(() =>
+            {
+                LoadFilePaths();
+            });
+
+            ReplaceAllCommand = this.CreateCommand(() =>
+            {
+                if (string.IsNullOrEmpty(SearchText))
+                {
+                    return;
+                }
+
+                foreach (var item in AllItems)
+                {
+                    if (item.FilePath.Contains(SearchText))
+                    {
+                        item.FilePath = item.FilePath.Replace(SearchText, ReplaceText);
+                    }
+                }
+
+                ApplyFilter();
+                NotifyPropertyChanged(nameof(InvalidCount));
+                NotifyPropertyChanged(nameof(WarningCount));
+                NotifyPropertyChanged(nameof(ValidCount));
+            });
+
+            BrowseCommand = this.CreateCommand(() =>
+            {
+                if (SelectedItem == null)
+                {
+                    return;
+                }
+
+                string filePath = ServiceManager.Get<IFileService>().ShowOpenFileDialog();
+                if (!string.IsNullOrEmpty(filePath))
+                {
+                    SelectedItem.FilePath = filePath;
+                    ApplyFilter();
+                    NotifyPropertyChanged(nameof(InvalidCount));
+                    NotifyPropertyChanged(nameof(WarningCount));
+                    NotifyPropertyChanged(nameof(ValidCount));
+                }
+            });
+
+            LocateMissingFilesCommand = this.CreateCommand(async () =>
+            {
+
+                string folderPath = ServiceManager.Get<IFileService>().ShowOpenFolderDialog();
+                if (string.IsNullOrEmpty(folderPath))
+                {
+                    return;
+                }
+
+                var invalidItems = AllItems.Where(i => !i.IsValid).ToList();
+                if (invalidItems.Count == 0)
+                {
+                    return;
+                }
+
+                var fileLookup = new MissingFilesCheckService().GetFileLookup(folderPath);
+
+                int fixedCount = 0;
+                foreach (var item in invalidItems)
+                {
+                    try
+                    {
+                        string targetFileName = Path.GetFileName(item.FilePath);
+                        if (!string.IsNullOrEmpty(targetFileName) && fileLookup.TryGetValue(targetFileName, out string newPath))
+                        {
+                            item.FilePath = newPath;
+                            fixedCount++;
+                        }
+                    }
+                    catch
+                    {
+                        // Ignore paths that are not valid file paths (e.g. URLs or special identifiers)
+                    }
+                }
+
+                if (fixedCount > 0)
+                {
+                    ApplyFilter();
+                    NotifyPropertyChanged(nameof(InvalidCount));
+                    NotifyPropertyChanged(nameof(WarningCount));
+                    NotifyPropertyChanged(nameof(ValidCount));
+                }
+            });
+
+            LoadFilePaths();
+        }
+
+        private void LoadFilePaths()
+        {
+            AllItems.Clear();
+            FilteredItems.Clear();
+
+            MissingFilesCheckService service = new MissingFilesCheckService();
+            List<MissingFilesCheckReference> references = service.GetAllFilePaths();
+
+            foreach (var reference in references)
+            {
+                AllItems.Add(new MissingFilesCheckItemViewModel(reference));
+            }
+
+            ApplyFilter();
+            NotifyPropertyChanged(nameof(TotalCount));
+            NotifyPropertyChanged(nameof(InvalidCount));
+            NotifyPropertyChanged(nameof(WarningCount));
+            NotifyPropertyChanged(nameof(ValidCount));
+        }
+
+        private void ApplyFilter()
+        {
+            FilteredItems.Clear();
+
+            IEnumerable<MissingFilesCheckItemViewModel> items = AllItems;
+            if (SelectedFilterStatus.HasValue)
+            {
+                items = items.Where(i => i.Status == SelectedFilterStatus.Value);
+            }
+
+            foreach (var item in items)
+            {
+                FilteredItems.Add(item);
+            }
+        }
+    }
+}

--- a/MixItUp.Base/ViewModel/MissingFilesCheck/MissingFilesCheckWindowViewModel.cs
+++ b/MixItUp.Base/ViewModel/MissingFilesCheck/MissingFilesCheckWindowViewModel.cs
@@ -6,6 +6,9 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using System.Windows.Input;
 using System.IO;
+using MixItUp.Base.Util;
+using System.Threading.Tasks;
+using MixItUp.Base.Model.Commands;
 
 namespace MixItUp.Base.ViewModel.MissingFilesCheck
 {
@@ -27,6 +30,7 @@ namespace MixItUp.Base.ViewModel.MissingFilesCheck
                 NotifyPropertyChanged();
                 NotifyPropertyChanged(nameof(Status));
                 NotifyPropertyChanged(nameof(IsValid));
+                _ = AsyncRunner.RunAsync(() => new MissingFilesCheckService().SaveCommand(Reference.Command));
             }
         }
 

--- a/MixItUp.WPF/Controls/Settings/AdvancedSettingsControl.xaml
+++ b/MixItUp.WPF/Controls/Settings/AdvancedSettingsControl.xaml
@@ -27,6 +27,13 @@
                 <TextBlock Grid.Column="2" Text="{Binding AutomaticBackupLocationFolderPath}" HorizontalAlignment="Right" />
             </Grid>
 
+
+            <Separator Margin="10" />
+
+            <GenericSettingsControls:GenericToggleSettingsOptionControl DataContext="{Binding PreviewProgram}" />
+
+            <Separator Margin="10" />
+
             <Grid Margin="20, 10">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="275" />
@@ -37,12 +44,6 @@
                 <TextBlock Grid.Column="0" Text="Check missing file paths in commands:" HorizontalAlignment="Left" VerticalAlignment="Center" TextWrapping="Wrap" />
                 <Button Grid.Column="2" Content="Check Paths" Click="MissingFilesButton_Click" Width="175" Height="40" />
             </Grid>
-
-            <Separator Margin="10" />
-
-            <GenericSettingsControls:GenericToggleSettingsOptionControl DataContext="{Binding PreviewProgram}" />
-
-            <Separator Margin="10" />
 
             <GenericSettingsControls:GenericButtonSettingsOptionControl DataContext="{Binding InstallationFolder}" />
             <GenericSettingsControls:GenericToggleSettingsOptionControl DataContext="{Binding DiagnosticLogging}" />

--- a/MixItUp.WPF/Controls/Settings/AdvancedSettingsControl.xaml
+++ b/MixItUp.WPF/Controls/Settings/AdvancedSettingsControl.xaml
@@ -41,8 +41,8 @@
                     <ColumnDefinition Width="Auto" />
                 </Grid.ColumnDefinitions>
 
-                <TextBlock Grid.Column="0" Text="Check missing file paths in commands:" HorizontalAlignment="Left" VerticalAlignment="Center" TextWrapping="Wrap" />
-                <Button Grid.Column="2" Content="Check Paths" Click="MissingFilesButton_Click" Width="175" Height="40" />
+                <TextBlock Grid.Column="0" Text="{x:Static resx:Resources.MissingFilesCheckDescription}" HorizontalAlignment="Left" VerticalAlignment="Center" TextWrapping="Wrap" />
+                <Button Grid.Column="2" Content="{x:Static resx:Resources.MissingFilesCheckPaths}" Click="MissingFilesButton_Click" Width="175" Height="40" />
             </Grid>
 
             <GenericSettingsControls:GenericButtonSettingsOptionControl DataContext="{Binding InstallationFolder}" />

--- a/MixItUp.WPF/Controls/Settings/AdvancedSettingsControl.xaml
+++ b/MixItUp.WPF/Controls/Settings/AdvancedSettingsControl.xaml
@@ -35,6 +35,16 @@
 
             <GenericSettingsControls:GenericButtonSettingsOptionControl DataContext="{Binding InstallationFolder}" />
             <GenericSettingsControls:GenericToggleSettingsOptionControl DataContext="{Binding DiagnosticLogging}" />
+
+            <Grid Margin="0,5">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+                <TextBlock VerticalAlignment="Center" Text="Missing Files Check" />
+                <Button Grid.Column="1" Content="Check" Click="ValidateFilePathsButton_Click" Width="125" />
+            </Grid>
+
             <GenericSettingsControls:GenericButtonSettingsOptionControl DataContext="{Binding RunNewUserWizard}" />
             <GenericSettingsControls:GenericButtonSettingsOptionControl DataContext="{Binding DeleteSettings}" />
         </StackPanel>

--- a/MixItUp.WPF/Controls/Settings/AdvancedSettingsControl.xaml
+++ b/MixItUp.WPF/Controls/Settings/AdvancedSettingsControl.xaml
@@ -27,6 +27,17 @@
                 <TextBlock Grid.Column="2" Text="{Binding AutomaticBackupLocationFolderPath}" HorizontalAlignment="Right" />
             </Grid>
 
+            <Grid Margin="20, 10">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="275" />
+                    <ColumnDefinition Width="20" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+
+                <TextBlock Grid.Column="0" Text="Check missing file paths in commands:" HorizontalAlignment="Left" VerticalAlignment="Center" TextWrapping="Wrap" />
+                <Button Grid.Column="2" Content="Check Paths" Click="MissingFilesButton_Click" Width="175" Height="40" />
+            </Grid>
+
             <Separator Margin="10" />
 
             <GenericSettingsControls:GenericToggleSettingsOptionControl DataContext="{Binding PreviewProgram}" />
@@ -35,16 +46,6 @@
 
             <GenericSettingsControls:GenericButtonSettingsOptionControl DataContext="{Binding InstallationFolder}" />
             <GenericSettingsControls:GenericToggleSettingsOptionControl DataContext="{Binding DiagnosticLogging}" />
-
-            <Grid Margin="0,5">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="*" />
-                    <ColumnDefinition Width="Auto" />
-                </Grid.ColumnDefinitions>
-                <TextBlock VerticalAlignment="Center" Text="Missing Files Check" />
-                <Button Grid.Column="1" Content="Check" Click="ValidateFilePathsButton_Click" Width="125" />
-            </Grid>
-
             <GenericSettingsControls:GenericButtonSettingsOptionControl DataContext="{Binding RunNewUserWizard}" />
             <GenericSettingsControls:GenericButtonSettingsOptionControl DataContext="{Binding DeleteSettings}" />
         </StackPanel>

--- a/MixItUp.WPF/Controls/Settings/AdvancedSettingsControl.xaml.cs
+++ b/MixItUp.WPF/Controls/Settings/AdvancedSettingsControl.xaml.cs
@@ -31,7 +31,7 @@ namespace MixItUp.WPF.Controls.Settings
             await this.InitializeInternal();
         }
 
-        private void ValidateFilePathsButton_Click(object sender, RoutedEventArgs e)
+        private void MissingFilesButton_Click(object sender, RoutedEventArgs e)
         {
             MissingFilesCheckWindow window = new MissingFilesCheckWindow();
             window.Show();

--- a/MixItUp.WPF/Controls/Settings/AdvancedSettingsControl.xaml.cs
+++ b/MixItUp.WPF/Controls/Settings/AdvancedSettingsControl.xaml.cs
@@ -33,10 +33,11 @@ namespace MixItUp.WPF.Controls.Settings
 
         private async void MissingFilesButton_Click(object sender, RoutedEventArgs e)
         {
-            if (await DialogHelper.ShowConfirmation("Before you continue, we recommend creating a backup of your profile using the Backup Settings button above. Continue?"))
+            if (await DialogHelper.ShowConfirmation(MixItUp.Base.Resources.MissingFilesCheckDialog))
             {
                 MissingFilesCheckWindow window = new MissingFilesCheckWindow();
                 window.Show();
+                window.Activate();
             }
         }
     }

--- a/MixItUp.WPF/Controls/Settings/AdvancedSettingsControl.xaml.cs
+++ b/MixItUp.WPF/Controls/Settings/AdvancedSettingsControl.xaml.cs
@@ -1,5 +1,8 @@
 ﻿using MixItUp.Base.ViewModel.Settings;
+using MixItUp.WPF.Windows.MissingFilesCheck;
 using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
 
 namespace MixItUp.WPF.Controls.Settings
 {
@@ -26,6 +29,12 @@ namespace MixItUp.WPF.Controls.Settings
         protected override async Task OnVisibilityChanged()
         {
             await this.InitializeInternal();
+        }
+
+        private void ValidateFilePathsButton_Click(object sender, RoutedEventArgs e)
+        {
+            MissingFilesCheckWindow window = new MissingFilesCheckWindow();
+            window.Show();
         }
     }
 }

--- a/MixItUp.WPF/Controls/Settings/AdvancedSettingsControl.xaml.cs
+++ b/MixItUp.WPF/Controls/Settings/AdvancedSettingsControl.xaml.cs
@@ -1,8 +1,8 @@
 ﻿using MixItUp.Base.ViewModel.Settings;
+using MixItUp.Base.Util;
 using MixItUp.WPF.Windows.MissingFilesCheck;
 using System.Threading.Tasks;
 using System.Windows;
-using System.Windows.Controls;
 
 namespace MixItUp.WPF.Controls.Settings
 {
@@ -31,10 +31,13 @@ namespace MixItUp.WPF.Controls.Settings
             await this.InitializeInternal();
         }
 
-        private void MissingFilesButton_Click(object sender, RoutedEventArgs e)
+        private async void MissingFilesButton_Click(object sender, RoutedEventArgs e)
         {
-            MissingFilesCheckWindow window = new MissingFilesCheckWindow();
-            window.Show();
+            if (await DialogHelper.ShowConfirmation("Before you continue, we recommend creating a backup of your profile using the Backup Settings button above. Continue?"))
+            {
+                MissingFilesCheckWindow window = new MissingFilesCheckWindow();
+                window.Show();
+            }
         }
     }
 }

--- a/MixItUp.WPF/Controls/Settings/AdvancedSettingsControl.xaml.cs
+++ b/MixItUp.WPF/Controls/Settings/AdvancedSettingsControl.xaml.cs
@@ -37,7 +37,6 @@ namespace MixItUp.WPF.Controls.Settings
             {
                 MissingFilesCheckWindow window = new MissingFilesCheckWindow();
                 window.Show();
-                window.Activate();
             }
         }
     }

--- a/MixItUp.WPF/Windows/MissingFilesCheck/MissingFilesCheckWindow.xaml
+++ b/MixItUp.WPF/Windows/MissingFilesCheck/MissingFilesCheckWindow.xaml
@@ -19,7 +19,6 @@
     Style="{StaticResource MaterialDesignWindow}"
     TextElement.FontSize="14"
     TextElement.FontWeight="Medium"
-    WindowStartupLocation="CenterScreen"
     mc:Ignorable="d">
 
     <Grid>

--- a/MixItUp.WPF/Windows/MissingFilesCheck/MissingFilesCheckWindow.xaml
+++ b/MixItUp.WPF/Windows/MissingFilesCheck/MissingFilesCheckWindow.xaml
@@ -214,8 +214,7 @@
                         </DataGridTextColumn>
                         <DataGridTextColumn
                             Width="*"
-                            MinWidth="300"
-                            Binding="{Binding FilePath, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                            Binding="{Binding FilePath, Mode=TwoWay}"
                             Header="File Path">
                             <DataGridTextColumn.ElementStyle>
                                 <Style TargetType="TextBlock">
@@ -257,8 +256,7 @@
                     MaterialDesign:HintAssist.Hint="Select a path"
                     FontSize="12"
                     IsEnabled="{Binding HasSelectedItem}"
-                    Style="{StaticResource MaterialDesignOutlinedTextBox}"
-                    Text="{Binding SelectedItem.FilePath, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                    Text="{Binding SelectedItem.FilePath, Mode=TwoWay}" />
                 <Button
                     Grid.Column="4"
                     Height="36"

--- a/MixItUp.WPF/Windows/MissingFilesCheck/MissingFilesCheckWindow.xaml
+++ b/MixItUp.WPF/Windows/MissingFilesCheck/MissingFilesCheckWindow.xaml
@@ -287,7 +287,6 @@
                     Height="36"
                     Padding="12,0"
                     Command="{Binding LocateMissingFilesCommand}"
-                    IsEnabled="True"
                     Style="{StaticResource MaterialDesignOutlinedButton}">
                     <StackPanel Orientation="Horizontal">
                         <MaterialDesign:PackIcon

--- a/MixItUp.WPF/Windows/MissingFilesCheck/MissingFilesCheckWindow.xaml
+++ b/MixItUp.WPF/Windows/MissingFilesCheck/MissingFilesCheckWindow.xaml
@@ -8,7 +8,8 @@
     xmlns:Windows="clr-namespace:MixItUp.WPF.Windows"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    Title="Missing Files Check"
+    xmlns:resx="clr-namespace:MixItUp.Base;assembly=MixItUp.Base"
+    Title="{x:Static resx:Resources.MissingFilesCheck}"
     Width="1100"
     Height="700"
     MinWidth="900"
@@ -49,7 +50,7 @@
                     SelectedIndex="{Binding SelectedFilterIndex}"
                     Style="{StaticResource MaterialDesignChoiceChipSecondaryOutlineListBox}">
 
-                    <ListBoxItem ToolTip="Show all paths">
+                    <ListBoxItem ToolTip="{x:Static resx:Resources.ShowAllPaths}">
                         <StackPanel Orientation="Horizontal">
                             <MaterialDesign:PackIcon
                                 Width="16"
@@ -66,7 +67,7 @@
                         </StackPanel>
                     </ListBoxItem>
 
-                    <ListBoxItem ToolTip="Show valid paths">
+                    <ListBoxItem ToolTip="{x:Static resx:Resources.ShowValidPaths}">
                         <StackPanel Orientation="Horizontal">
                             <MaterialDesign:PackIcon
                                 Width="16"
@@ -83,7 +84,7 @@
                         </StackPanel>
                     </ListBoxItem>
 
-                    <ListBoxItem ToolTip="Show warning paths">
+                    <ListBoxItem ToolTip="{x:Static resx:Resources.ShowWarningPaths}">
                         <StackPanel Orientation="Horizontal">
                             <MaterialDesign:PackIcon
                                 Width="16"
@@ -100,7 +101,7 @@
                         </StackPanel>
                     </ListBoxItem>
 
-                    <ListBoxItem ToolTip="Show missing paths">
+                    <ListBoxItem ToolTip="{x:Static resx:Resources.ShowMissingPaths}">
                         <StackPanel Orientation="Horizontal">
                             <MaterialDesign:PackIcon
                                 Width="16"
@@ -129,7 +130,7 @@
                             Margin="0,0,8,0"
                             VerticalAlignment="Center"
                             Kind="Refresh" />
-                        <TextBlock VerticalAlignment="Center" Text="Rescan" />
+                        <TextBlock VerticalAlignment="Center" Text="{x:Static resx:Resources.Rescan}" />
                     </StackPanel>
                 </Button>
             </Grid>
@@ -158,7 +159,7 @@
                     <DataGrid.Columns>
                         <DataGridTemplateColumn
                             Width="80"
-                            Header="Status"
+                            Header="{x:Static resx:Resources.Status}"
                             IsReadOnly="True">
                             <DataGridTemplateColumn.CellTemplate>
                                 <DataTemplate>
@@ -192,7 +193,7 @@
                         <DataGridTextColumn
                             Width="180"
                             Binding="{Binding CommandName}"
-                            Header="Command"
+                            Header="{x:Static resx:Resources.Command}"
                             IsReadOnly="True">
                             <DataGridTextColumn.ElementStyle>
                                 <Style TargetType="TextBlock">
@@ -204,7 +205,7 @@
                         <DataGridTextColumn
                             Width="140"
                             Binding="{Binding ActionType}"
-                            Header="Action Type"
+                            Header="{x:Static resx:Resources.ActionType}"
                             IsReadOnly="True">
                             <DataGridTextColumn.ElementStyle>
                                 <Style TargetType="TextBlock">
@@ -215,7 +216,7 @@
                         <DataGridTextColumn
                             Width="*"
                             Binding="{Binding FilePath, Mode=TwoWay}"
-                            Header="File Path">
+                            Header="{x:Static resx:Resources.FilePath}">
                             <DataGridTextColumn.ElementStyle>
                                 <Style TargetType="TextBlock">
                                     <Setter Property="VerticalAlignment" Value="Center" />
@@ -248,12 +249,12 @@
                     Grid.Column="0"
                     VerticalAlignment="Center"
                     FontWeight="Medium"
-                    Text="Selected Path:" />
+                    Text="{x:Static resx:Resources.SelectedPath}" />
                 <TextBox
                     Grid.Column="2"
                     Padding="8,6"
                     VerticalAlignment="Center"
-                    MaterialDesign:HintAssist.Hint="Select a path"
+                    MaterialDesign:HintAssist.Hint="{x:Static resx:Resources.SelectAPath}"
                     FontSize="12"
                     IsEnabled="{Binding HasSelectedItem}"
                     Text="{Binding SelectedItem.FilePath, Mode=TwoWay}" />
@@ -271,7 +272,7 @@
                             Margin="0,0,6,0"
                             VerticalAlignment="Center"
                             Kind="FolderOpen" />
-                        <TextBlock VerticalAlignment="Center" Text="Browse" />
+                        <TextBlock VerticalAlignment="Center" Text="{x:Static resx:Resources.Browse}" />
                     </StackPanel>
                 </Button>
 
@@ -295,7 +296,7 @@
                             Margin="0,0,6,0"
                             VerticalAlignment="Center"
                             Kind="FolderSearch" />
-                        <TextBlock VerticalAlignment="Center" Text="Search Folder" />
+                        <TextBlock VerticalAlignment="Center" Text="{x:Static resx:Resources.SearchFolder}" />
                     </StackPanel>
                 </Button>
             </Grid>
@@ -317,7 +318,7 @@
                     Grid.Column="0"
                     VerticalAlignment="Center"
                     FontWeight="Medium"
-                    Text="Search:" />
+                    Text="{x:Static resx:Resources.Search}" />
                 <TextBox
                     Grid.Column="2"
                     Padding="8,6"
@@ -331,7 +332,7 @@
                     Grid.Column="4"
                     VerticalAlignment="Center"
                     FontWeight="Medium"
-                    Text="Replace:" />
+                    Text="{x:Static resx:Resources.Replace}" />
                 <TextBox
                     Grid.Column="6"
                     Padding="8,6"
@@ -354,7 +355,7 @@
                             Margin="0,0,6,0"
                             VerticalAlignment="Center"
                             Kind="FindReplace" />
-                        <TextBlock VerticalAlignment="Center" Text="Replace All" />
+                        <TextBlock VerticalAlignment="Center" Text="{x:Static resx:Resources.ReplaceAll}" />
                     </StackPanel>
                 </Button>
             </Grid>

--- a/MixItUp.WPF/Windows/MissingFilesCheck/MissingFilesCheckWindow.xaml
+++ b/MixItUp.WPF/Windows/MissingFilesCheck/MissingFilesCheckWindow.xaml
@@ -1,0 +1,367 @@
+<Window
+    x:Class="MixItUp.WPF.Windows.MissingFilesCheck.MissingFilesCheckWindow"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:Controls="clr-namespace:MixItUp.WPF.Controls"
+    xmlns:MaterialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
+    xmlns:Services="clr-namespace:MixItUp.Base.Services;assembly=MixItUp.Base"
+    xmlns:Windows="clr-namespace:MixItUp.WPF.Windows"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    Title="Missing Files Check"
+    Width="1100"
+    Height="700"
+    MinWidth="900"
+    MinHeight="600"
+    FontFamily="{MaterialDesign:MaterialDesignFont}"
+    Icon="./../../Logo.ico"
+    Style="{StaticResource MaterialDesignWindow}"
+    TextElement.FontSize="14"
+    TextElement.FontWeight="Medium"
+    WindowStartupLocation="CenterScreen"
+    mc:Ignorable="d">
+
+    <Grid>
+
+        <MaterialDesign:DialogHost x:Name="MDDialogHost" Identifier="RootDialog" />
+
+        <Grid Margin="24">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="16" />
+                <RowDefinition Height="*" />
+                <RowDefinition Height="20" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="16" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+
+            <Grid Grid.Row="0">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+
+                <ListBox
+                    Grid.Column="0"
+                    VerticalAlignment="Center"
+                    SelectedIndex="{Binding SelectedFilterIndex}"
+                    Style="{StaticResource MaterialDesignChoiceChipSecondaryOutlineListBox}">
+
+                    <ListBoxItem ToolTip="Show all paths">
+                        <StackPanel Orientation="Horizontal">
+                            <MaterialDesign:PackIcon
+                                Width="16"
+                                Height="16"
+                                Margin="0,0,6,0"
+                                VerticalAlignment="Center"
+                                Kind="FolderMultipleImage"
+                                Opacity="0.7" />
+                            <TextBlock
+                                VerticalAlignment="Center"
+                                FontWeight="SemiBold"
+                                Opacity="0.7"
+                                Text="{Binding TotalCount}" />
+                        </StackPanel>
+                    </ListBoxItem>
+
+                    <ListBoxItem ToolTip="Show valid paths">
+                        <StackPanel Orientation="Horizontal">
+                            <MaterialDesign:PackIcon
+                                Width="16"
+                                Height="16"
+                                Margin="0,0,6,0"
+                                VerticalAlignment="Center"
+                                Foreground="#4CAF50"
+                                Kind="CheckCircleOutline" />
+                            <TextBlock
+                                VerticalAlignment="Center"
+                                FontWeight="SemiBold"
+                                Foreground="#4CAF50"
+                                Text="{Binding ValidCount}" />
+                        </StackPanel>
+                    </ListBoxItem>
+
+                    <ListBoxItem ToolTip="Show warning paths">
+                        <StackPanel Orientation="Horizontal">
+                            <MaterialDesign:PackIcon
+                                Width="16"
+                                Height="16"
+                                Margin="0,0,6,0"
+                                VerticalAlignment="Center"
+                                Foreground="#FFA500"
+                                Kind="AlertCircleOutline" />
+                            <TextBlock
+                                VerticalAlignment="Center"
+                                FontWeight="SemiBold"
+                                Foreground="#FFA500"
+                                Text="{Binding WarningCount}" />
+                        </StackPanel>
+                    </ListBoxItem>
+
+                    <ListBoxItem ToolTip="Show missing paths">
+                        <StackPanel Orientation="Horizontal">
+                            <MaterialDesign:PackIcon
+                                Width="16"
+                                Height="16"
+                                Margin="0,0,6,0"
+                                VerticalAlignment="Center"
+                                Foreground="#F44336"
+                                Kind="CloseCircleOutline" />
+                            <TextBlock
+                                VerticalAlignment="Center"
+                                FontWeight="SemiBold"
+                                Foreground="#F44336"
+                                Text="{Binding InvalidCount}" />
+                        </StackPanel>
+                    </ListBoxItem>
+                </ListBox>
+
+                <Button
+                    Grid.Column="2"
+                    Height="36"
+                    Padding="16,0"
+                    Command="{Binding ScanCommand}"
+                    Style="{StaticResource MaterialDesignOutlinedButton}">
+                    <StackPanel Orientation="Horizontal">
+                        <MaterialDesign:PackIcon
+                            Margin="0,0,8,0"
+                            VerticalAlignment="Center"
+                            Kind="Refresh" />
+                        <TextBlock VerticalAlignment="Center" Text="Rescan" />
+                    </StackPanel>
+                </Button>
+            </Grid>
+
+            <Border
+                Grid.Row="2"
+                BorderBrush="{DynamicResource MaterialDesignDivider}"
+                BorderThickness="1"
+                CornerRadius="4">
+                <DataGrid
+                    AutoGenerateColumns="False"
+                    Background="Transparent"
+                    BorderThickness="0"
+                    CanUserAddRows="False"
+                    CanUserDeleteRows="False"
+                    ColumnHeaderHeight="36"
+                    GridLinesVisibility="Horizontal"
+                    HeadersVisibility="Column"
+                    HorizontalScrollBarVisibility="Auto"
+                    IsReadOnly="False"
+                    ItemsSource="{Binding FilteredItems}"
+                    RowHeight="34"
+                    SelectedItem="{Binding SelectedItem}"
+                    SelectionMode="Single"
+                    VerticalScrollBarVisibility="Auto">
+                    <DataGrid.Columns>
+                        <DataGridTemplateColumn
+                            Width="80"
+                            Header="Status"
+                            IsReadOnly="True">
+                            <DataGridTemplateColumn.CellTemplate>
+                                <DataTemplate>
+                                    <MaterialDesign:PackIcon
+                                        Width="20"
+                                        Height="20"
+                                        HorizontalAlignment="Center"
+                                        VerticalAlignment="Center">
+                                        <MaterialDesign:PackIcon.Style>
+                                            <Style TargetType="MaterialDesign:PackIcon">
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding Status}" Value="{x:Static Services:MissingFilesCheckStatus.Valid}">
+                                                        <Setter Property="Kind" Value="CheckCircle" />
+                                                        <Setter Property="Foreground" Value="#4CAF50" />
+                                                    </DataTrigger>
+                                                    <DataTrigger Binding="{Binding Status}" Value="{x:Static Services:MissingFilesCheckStatus.Warning}">
+                                                        <Setter Property="Kind" Value="AlertCircle" />
+                                                        <Setter Property="Foreground" Value="#FFA500" />
+                                                    </DataTrigger>
+                                                    <DataTrigger Binding="{Binding Status}" Value="{x:Static Services:MissingFilesCheckStatus.Invalid}">
+                                                        <Setter Property="Kind" Value="CloseCircle" />
+                                                        <Setter Property="Foreground" Value="#F44336" />
+                                                    </DataTrigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </MaterialDesign:PackIcon.Style>
+                                    </MaterialDesign:PackIcon>
+                                </DataTemplate>
+                            </DataGridTemplateColumn.CellTemplate>
+                        </DataGridTemplateColumn>
+                        <DataGridTextColumn
+                            Width="180"
+                            Binding="{Binding CommandName}"
+                            Header="Command"
+                            IsReadOnly="True">
+                            <DataGridTextColumn.ElementStyle>
+                                <Style TargetType="TextBlock">
+                                    <Setter Property="VerticalAlignment" Value="Center" />
+                                    <Setter Property="TextTrimming" Value="CharacterEllipsis" />
+                                </Style>
+                            </DataGridTextColumn.ElementStyle>
+                        </DataGridTextColumn>
+                        <DataGridTextColumn
+                            Width="140"
+                            Binding="{Binding ActionType}"
+                            Header="Action Type"
+                            IsReadOnly="True">
+                            <DataGridTextColumn.ElementStyle>
+                                <Style TargetType="TextBlock">
+                                    <Setter Property="VerticalAlignment" Value="Center" />
+                                </Style>
+                            </DataGridTextColumn.ElementStyle>
+                        </DataGridTextColumn>
+                        <DataGridTextColumn
+                            Width="*"
+                            MinWidth="300"
+                            Binding="{Binding FilePath, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                            Header="File Path">
+                            <DataGridTextColumn.ElementStyle>
+                                <Style TargetType="TextBlock">
+                                    <Setter Property="VerticalAlignment" Value="Center" />
+                                    <Setter Property="TextTrimming" Value="CharacterEllipsis" />
+                                    <Setter Property="ToolTip" Value="{Binding FilePath}" />
+                                </Style>
+                            </DataGridTextColumn.ElementStyle>
+                            <DataGridTextColumn.EditingElementStyle>
+                                <Style TargetType="TextBox">
+                                    <Setter Property="VerticalAlignment" Value="Center" />
+                                </Style>
+                            </DataGridTextColumn.EditingElementStyle>
+                        </DataGridTextColumn>
+                    </DataGrid.Columns>
+                </DataGrid>
+            </Border>
+
+            <Grid Grid.Row="4" Margin="0,4">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="12" />
+                    <ColumnDefinition Width="2*" />
+                    <ColumnDefinition Width="12" />
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="32" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+
+                <TextBlock
+                    Grid.Column="0"
+                    VerticalAlignment="Center"
+                    FontWeight="Medium"
+                    Text="Selected Path:" />
+                <TextBox
+                    Grid.Column="2"
+                    Padding="8,6"
+                    VerticalAlignment="Center"
+                    MaterialDesign:HintAssist.Hint="Select a path"
+                    FontSize="12"
+                    IsEnabled="{Binding HasSelectedItem}"
+                    Style="{StaticResource MaterialDesignOutlinedTextBox}"
+                    Text="{Binding SelectedItem.FilePath, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                <Button
+                    Grid.Column="4"
+                    Height="36"
+                    Padding="12,0"
+                    Command="{Binding BrowseCommand}"
+                    IsEnabled="{Binding HasSelectedItem}"
+                    Style="{StaticResource MaterialDesignOutlinedButton}">
+                    <StackPanel Orientation="Horizontal">
+                        <MaterialDesign:PackIcon
+                            Width="18"
+                            Height="18"
+                            Margin="0,0,6,0"
+                            VerticalAlignment="Center"
+                            Kind="FolderOpen" />
+                        <TextBlock VerticalAlignment="Center" Text="Browse" />
+                    </StackPanel>
+                </Button>
+
+                <Border
+                    Grid.Column="5"
+                    Width="1"
+                    Margin="0,4"
+                    VerticalAlignment="Stretch"
+                    Background="{DynamicResource MaterialDesignDivider}" />
+
+                <Button
+                    Grid.Column="6"
+                    Height="36"
+                    Padding="12,0"
+                    Command="{Binding LocateMissingFilesCommand}"
+                    IsEnabled="True"
+                    Style="{StaticResource MaterialDesignOutlinedButton}">
+                    <StackPanel Orientation="Horizontal">
+                        <MaterialDesign:PackIcon
+                            Width="18"
+                            Height="18"
+                            Margin="0,0,6,0"
+                            VerticalAlignment="Center"
+                            Kind="FolderSearch" />
+                        <TextBlock VerticalAlignment="Center" Text="Search Folder" />
+                    </StackPanel>
+                </Button>
+            </Grid>
+
+            <Grid Grid.Row="6" Margin="0,4">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="12" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="20" />
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="12" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="20" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+
+                <TextBlock
+                    Grid.Column="0"
+                    VerticalAlignment="Center"
+                    FontWeight="Medium"
+                    Text="Search:" />
+                <TextBox
+                    Grid.Column="2"
+                    Padding="8,6"
+                    VerticalAlignment="Center"
+                    MaterialDesign:HintAssist.Hint="C:\Users\OldName\Sounds"
+                    FontSize="12"
+                    Style="{StaticResource MaterialDesignOutlinedTextBox}"
+                    Text="{Binding SearchText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+
+                <TextBlock
+                    Grid.Column="4"
+                    VerticalAlignment="Center"
+                    FontWeight="Medium"
+                    Text="Replace:" />
+                <TextBox
+                    Grid.Column="6"
+                    Padding="8,6"
+                    VerticalAlignment="Center"
+                    MaterialDesign:HintAssist.Hint="C:\Users\NewName\Sounds"
+                    FontSize="12"
+                    Style="{StaticResource MaterialDesignOutlinedTextBox}"
+                    Text="{Binding ReplaceText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+
+                <Button
+                    Grid.Column="8"
+                    Height="36"
+                    Padding="16,0"
+                    Command="{Binding ReplaceAllCommand}"
+                    Style="{StaticResource MaterialDesignRaisedButton}">
+                    <StackPanel Orientation="Horizontal">
+                        <MaterialDesign:PackIcon
+                            Width="18"
+                            Height="18"
+                            Margin="0,0,6,0"
+                            VerticalAlignment="Center"
+                            Kind="FindReplace" />
+                        <TextBlock VerticalAlignment="Center" Text="Replace All" />
+                    </StackPanel>
+                </Button>
+            </Grid>
+        </Grid>
+    </Grid>
+</Window>
+

--- a/MixItUp.WPF/Windows/MissingFilesCheck/MissingFilesCheckWindow.xaml
+++ b/MixItUp.WPF/Windows/MissingFilesCheck/MissingFilesCheckWindow.xaml
@@ -56,7 +56,7 @@
                                 Height="16"
                                 Margin="0,0,6,0"
                                 VerticalAlignment="Center"
-                                Kind="FolderMultipleImage"
+                                Kind="FileMultiple"
                                 Opacity="0.7" />
                             <TextBlock
                                 VerticalAlignment="Center"

--- a/MixItUp.WPF/Windows/MissingFilesCheck/MissingFilesCheckWindow.xaml.cs
+++ b/MixItUp.WPF/Windows/MissingFilesCheck/MissingFilesCheckWindow.xaml.cs
@@ -1,0 +1,15 @@
+using MixItUp.Base.ViewModel.MissingFilesCheck;
+using System.Windows;
+
+namespace MixItUp.WPF.Windows.MissingFilesCheck
+{
+    public partial class MissingFilesCheckWindow : Window
+    {
+        public MissingFilesCheckWindow()
+        {
+            InitializeComponent();
+
+            this.DataContext = new MissingFilesCheckWindowViewModel();
+        }
+    }
+}


### PR DESCRIPTION
Completed.

 Added the Missing Files Check page where users can see all their actions that have paths. They can do a simple fix per command, do a full search&replace for specific keywords or paths, or use the "Search Folder" button which searches a specific folder and its content for any media that matches the missing files

<img width="1086" height="693" alt="Image" src="https://github.com/user-attachments/assets/ba37d2c1-c21a-44d3-8658-b6e5f2709fd2" />