### PR TITLE
fix: Tiltify donations triggering old alerts on app startup.

### DIFF
--- a/MixItUp.Base/Services/External/TiltifyService.cs
+++ b/MixItUp.Base/Services/External/TiltifyService.cs
@@ -188,8 +188,6 @@ namespace MixItUp.Base.Services.External
                     {
                         token.expiresIn = int.MaxValue;
 
-                        this.startTime = DateTimeOffset.Now;
-
                         return await this.InitializeInternal();
                     }
                 }
@@ -295,6 +293,7 @@ namespace MixItUp.Base.Services.External
         protected override async Task<Result> InitializeInternal()
         {
             this.cancellationTokenSource = new CancellationTokenSource();
+            this.startTime = DateTimeOffset.Now;
 
             this.user = await this.GetUser();
             if (this.user != null)


### PR DESCRIPTION
Moved startTime initialization from Connect() to InitializeInternal() so it's properly set during both manual login and automatic reconnection with saved OAuth token.