### PR TITLE
v1.6.312 Release

### DIFF
--- a/APIs/MixItUp.API/MixItUp.API.csproj
+++ b/APIs/MixItUp.API/MixItUp.API.csproj
@@ -5,8 +5,8 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<AssemblyTitle>MixItUp.API</AssemblyTitle>
-    <AssemblyVersion>1.6.311.0</AssemblyVersion>
-    <FileVersion>1.6.311.0</FileVersion>
+    <AssemblyVersion>1.6.312.0</AssemblyVersion>
+    <FileVersion>1.6.312.0</FileVersion>
 		<Company>Blazing Cacti LLC</Company>
 		<Copyright>Copyright © 2026 Blazing Cacti LLC, All Rights Reserved. </Copyright>
 	</PropertyGroup>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Mix It Up Desktop Changelog
 
+## 1.6.312
+
+- [MAINT] Update WebSocket error handling
+- [MAINT] Remove pre-made headers for Web Request action
+- [MAINT] Update Window redesign and improvements when handling mandatory updates
+- [MAINT] Update Chagelog page to point to local file instead of external URL
+- [FEAT] Add save source screenshot option to Streaming Software action (OBS Studio only)
+- [FEAT] Add delete all quotes button
+- [FIX] Additional OBS Studio WebSocket connectivity improvements and fix source visibility in groups
+- [FIX] Renumbering quotes saving on app shutdown
+- [FIX] Streamlabs Desktop source visibility fixed for dual output scenes
+- [FIX] Crashes when receiving mass gifted subs, and fix total gifted tracking
+
 ## 1.6.311
 
 - [MAINT] Significant improvements when opening the command editor and loading various actions

--- a/MixItUp.Base/MixItUp.Base.csproj
+++ b/MixItUp.Base/MixItUp.Base.csproj
@@ -3,8 +3,8 @@
   	<PropertyGroup>
 		<TargetFramework>net8.0</TargetFramework>
 		<AssemblyTitle>MixItUp.Base</AssemblyTitle>
-    <AssemblyVersion>1.6.311.0</AssemblyVersion>
-    <FileVersion>1.6.311.0</FileVersion>
+    <AssemblyVersion>1.6.312.0</AssemblyVersion>
+    <FileVersion>1.6.312.0</FileVersion>
 		<Company>Blazing Cacti LLC</Company>
 		<Copyright>Copyright © 2026 Blazing Cacti LLC, All Rights Reserved. </Copyright>
 	</PropertyGroup>

--- a/MixItUp.Base/Model/Actions/StreamingSoftwareActionModel.cs
+++ b/MixItUp.Base/Model/Actions/StreamingSoftwareActionModel.cs
@@ -39,6 +39,7 @@ namespace MixItUp.Base.Model.Actions
 
         ImageSource,
         MediaSource,
+        SaveSourceScreenshot,
     }
 
     [DataContract]
@@ -164,6 +165,17 @@ namespace MixItUp.Base.Model.Actions
             return action;
         }
 
+        public static StreamingSoftwareActionModel CreateSaveSourceScreenshotAction(StreamingSoftwareTypeEnum softwareType, string sourceName, string imageFormat, string imageFilePath, int? imageWidth, int? imageHeight)
+        {
+            StreamingSoftwareActionModel action = new StreamingSoftwareActionModel(softwareType, StreamingSoftwareActionTypeEnum.SaveSourceScreenshot);
+            action.ItemName = sourceName;
+            action.ImageFormat = imageFormat;
+            action.ImageFilePath = imageFilePath;
+            action.ImageWidth = imageWidth;
+            action.ImageHeight = imageHeight;
+            return action;
+        }
+
         public static StreamingSoftwareActionModel CreateSourceDimensionsAction(StreamingSoftwareTypeEnum softwareType, string sceneName, string sourceName, bool sourceVisible, StreamingSoftwareSourceDimensionsModel sourceDimensions)
         {
             StreamingSoftwareActionModel action = StreamingSoftwareActionModel.CreateSourceVisibilityAction(softwareType, sceneName, sourceName, sourceVisible);
@@ -203,6 +215,15 @@ namespace MixItUp.Base.Model.Actions
 
         [DataMember]
         public StreamingSoftwareSourceDimensionsModel SourceDimensions { get; set; }
+
+        [DataMember]
+        public string ImageFormat { get; set; }
+        [DataMember]
+        public string ImageFilePath { get; set; }
+        [DataMember]
+        public int? ImageWidth { get; set; }
+        [DataMember]
+        public int? ImageHeight { get; set; }
 
         public StreamingSoftwareActionModel(StreamingSoftwareTypeEnum softwareType, StreamingSoftwareActionTypeEnum actionType)
             : base(ActionTypeEnum.StreamingSoftware)
@@ -330,7 +351,18 @@ namespace MixItUp.Base.Model.Actions
                         {
                             await ssService.SetSourceDimensions(parentName, name, this.SourceDimensions);
                         }
-                        await ssService.SetSourceVisibility(parentName, name, this.Visible);
+
+                        if (this.ActionType == StreamingSoftwareActionTypeEnum.SaveSourceScreenshot)
+                        {
+                            if (!string.IsNullOrEmpty(this.ImageFormat) && !string.IsNullOrEmpty(this.ImageFilePath))
+                            {
+                                await ssService.SaveSourceScreenshot(name, await ReplaceStringWithSpecialModifiers(this.ImageFormat, parameters), await ReplaceStringWithSpecialModifiers(this.ImageFilePath, parameters), this.ImageWidth, this.ImageHeight);
+                            }
+                        }
+                        else
+                        {
+                            await ssService.SetSourceVisibility(parentName, name, this.Visible);
+                        }
                     }
                 }
             }

--- a/MixItUp.Base/Model/Actions/WebRequestActionModel.cs
+++ b/MixItUp.Base/Model/Actions/WebRequestActionModel.cs
@@ -1,8 +1,5 @@
 ﻿using MixItUp.Base.Model.Commands;
 using MixItUp.Base.Services;
-using MixItUp.Base.Services.Trovo;
-using MixItUp.Base.Services.Twitch;
-using MixItUp.Base.Services.YouTube;
 using Newtonsoft.Json.Linq;
 using MixItUp.Base.Util;
 using MixItUp.Base.Web;
@@ -15,9 +12,6 @@ using System.Runtime.Serialization;
 using System.Text;
 using System.Threading.Tasks;
 using System.Web;
-using MixItUp.Base.Services.Trovo.New;
-using MixItUp.Base.Services.Twitch.New;
-using MixItUp.Base.Services.YouTube.New;
 
 namespace MixItUp.Base.Model.Actions
 {
@@ -89,12 +83,6 @@ namespace MixItUp.Base.Model.Actions
                 using (AdvancedHttpClient httpClient = new AdvancedHttpClient())
                 {
                     httpClient.DefaultRequestHeaders.Add("User-Agent", $"MixItUp/{Assembly.GetEntryAssembly().GetName().Version.ToString()} (Web call from Mix It Up; https://mixitupapp.com; support@mixitupapp.com)");
-                    httpClient.DefaultRequestHeaders.Add("Twitch-UserID", ServiceManager.Get<TwitchSession>()?.StreamerID ?? string.Empty);
-                    httpClient.DefaultRequestHeaders.Add("Twitch-UserLogin", ServiceManager.Get<TwitchSession>().StreamerUsername ?? string.Empty);
-                    httpClient.DefaultRequestHeaders.Add("YouTube-UserID", ServiceManager.Get<YouTubeSession>()?.StreamerID ?? string.Empty);
-                    httpClient.DefaultRequestHeaders.Add("YouTube-UserLogin", Uri.EscapeDataString(ServiceManager.Get<YouTubeSession>().StreamerUsername ?? string.Empty));
-                    httpClient.DefaultRequestHeaders.Add("Trovo-UserID", ServiceManager.Get<TrovoSession>()?.StreamerID ?? string.Empty);
-                    httpClient.DefaultRequestHeaders.Add("Trovo-UserLogin", ServiceManager.Get<TrovoSession>().StreamerUsername ?? string.Empty);
 
                     if (this.CustomHeaders != null)
                     {

--- a/MixItUp.Base/Model/Overlay/OverlayCustomV3Model.cs
+++ b/MixItUp.Base/Model/Overlay/OverlayCustomV3Model.cs
@@ -107,15 +107,22 @@ namespace MixItUp.Base.Model.Overlay
 
         public override async void OnMassSubscription(object sender, IEnumerable<SubscriptionDetailsModel> subscriptions)
         {
-            StreamingPlatformTypeEnum platform = subscriptions.First().Platform;
-            UserV2ViewModel gifter = subscriptions.First().Gifter;
-            int tier = subscriptions.First().Tier;
-            string membershipName = subscriptions.First().YouTubeMembershipTier;
-            int amount = subscriptions.Count();
+            List<SubscriptionDetailsModel> subscriptionList = subscriptions?.Where(s => s != null).ToList();
+            if (subscriptionList == null || subscriptionList.Count == 0)
+            {
+                return;
+            }
+
+            SubscriptionDetailsModel firstSubscription = subscriptionList[0];
+            StreamingPlatformTypeEnum platform = firstSubscription.Platform;
+            UserV2ViewModel gifter = firstSubscription.Gifter;
+            int tier = firstSubscription.Tier;
+            string membershipName = firstSubscription.YouTubeMembershipTier;
+            int amount = subscriptionList.Count;
 
             Dictionary<string, object> data = new Dictionary<string, object>()
             {
-                { "Users", subscriptions.Select(s => s.User) },
+                { "Users", subscriptionList.Select(s => s.User) },
                 { "Tier", tier.ToString() },
                 { "Amount", amount },
                 { "Gifter", gifter }

--- a/MixItUp.Base/Model/Overlay/OverlayEventListV3Model.cs
+++ b/MixItUp.Base/Model/Overlay/OverlayEventListV3Model.cs
@@ -173,11 +173,18 @@ namespace MixItUp.Base.Model.Overlay
 
         public override async void OnMassSubscription(object sender, IEnumerable<SubscriptionDetailsModel> subscriptions)
         {
-            StreamingPlatformTypeEnum platform = subscriptions.First().Platform;
-            UserV2ViewModel gifter = subscriptions.First().Gifter;
-            int tier = subscriptions.First().Tier;
-            string membershipName = subscriptions.First().YouTubeMembershipTier;
-            int amount = subscriptions.Count();
+            List<SubscriptionDetailsModel> subscriptionList = subscriptions?.Where(s => s != null).ToList();
+            if (subscriptionList == null || subscriptionList.Count == 0)
+            {
+                return;
+            }
+
+            SubscriptionDetailsModel firstSubscription = subscriptionList[0];
+            StreamingPlatformTypeEnum platform = firstSubscription.Platform;
+            UserV2ViewModel gifter = firstSubscription.Gifter;
+            int tier = firstSubscription.Tier;
+            string membershipName = firstSubscription.YouTubeMembershipTier;
+            int amount = subscriptionList.Count;
 
             if (platform == StreamingPlatformTypeEnum.Twitch)
             {

--- a/MixItUp.Base/Model/Settings/SettingsV3Model.cs
+++ b/MixItUp.Base/Model/Settings/SettingsV3Model.cs
@@ -985,6 +985,39 @@ namespace MixItUp.Base.Model.Settings
             }
         }
 
+        // to do: move somewhere else (Viewmodel or QuoteService?)
+        public async Task SaveRenumberedQuotes()
+        {
+            List<UserQuoteModel> allQuotes = this.Quotes.ToList();
+            if (allQuotes.Count == 0)
+            {
+                return;
+            }
+
+            await ServiceManager.Get<IDatabaseService>().BulkWrite(this.DatabaseFilePath,
+                "REPLACE INTO Quotes(ID, Quote, GameName, DateTime) VALUES($ID, $Quote, $GameName, $DateTime)",
+                allQuotes.Select(q => new Dictionary<string, object>()
+                {
+                    { "$ID", q.ID.ToString() },
+                    { "$Quote", q.Quote },
+                    { "$GameName", q.GameName },
+                    { "$DateTime", q.DateTime.ToString() }
+                }));
+
+            await ServiceManager.Get<IDatabaseService>().Write(this.DatabaseFilePath,
+                $"DELETE FROM Quotes WHERE ID > {allQuotes.Count}");
+
+            this.Quotes.ClearTracking();
+        }
+
+        // to do: move somewhere else (Viewmodel or QuoteService?)
+        public async Task DeleteAllQuotes()
+        {
+            this.Quotes.Clear();
+            await ServiceManager.Get<IDatabaseService>().Write(this.DatabaseFilePath, "DELETE FROM Quotes");
+            this.Quotes.ClearTracking();
+        }
+
         public async Task SaveDatabaseData()
         {
             IEnumerable<Guid> removedUsers = this.Users.GetRemovedValues();

--- a/MixItUp.Base/Model/Twitch/Subscriptions/TwitchMassGiftedSubcriptionsEventModel.cs
+++ b/MixItUp.Base/Model/Twitch/Subscriptions/TwitchMassGiftedSubcriptionsEventModel.cs
@@ -13,7 +13,7 @@ namespace MixItUp.Base.Model.Twitch.Subscriptions
 
         public int TotalGifted { get; set; }
 
-        public int LifetimeGifted { get; set; }
+        public int? LifetimeGifted { get; set; }
 
         public int Tier { get; set; }
 
@@ -33,7 +33,7 @@ namespace MixItUp.Base.Model.Twitch.Subscriptions
             this.CommunityGiftID = communitySubGift.id;
 
             this.TotalGifted = communitySubGift.total.GetValueOrDefault();
-            this.LifetimeGifted = communitySubGift.cumulative_total.GetValueOrDefault();
+            this.LifetimeGifted = communitySubGift.cumulative_total;
 
             this.Tier = communitySubGift.TierNumber;
             this.TierName = this.TierName = $"{MixItUp.Base.Resources.Tier} {this.Tier}";

--- a/MixItUp.Base/Resources.Designer.cs
+++ b/MixItUp.Base/Resources.Designer.cs
@@ -5171,6 +5171,24 @@ namespace MixItUp.Base {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Delete All Quotes.
+        /// </summary>
+        public static string DeleteAllQuotes {
+            get {
+                return ResourceManager.GetString("DeleteAllQuotes", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Are you sure you want to delete ALL quotes? This action cannot be undone.
+        /// </summary>
+        public static string DeleteAllQuotesWarning {
+            get {
+                return ResourceManager.GetString("DeleteAllQuotesWarning", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Delete Chat Commands When Run.
         /// </summary>
         public static string DeleteChatCommandsWhenRun {

--- a/MixItUp.Base/Resources.Designer.cs
+++ b/MixItUp.Base/Resources.Designer.cs
@@ -24123,6 +24123,15 @@ namespace MixItUp.Base {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to This update is required to continue using Mix It Up.
+        /// </summary>
+        public static string ThisUpdateIsRequired {
+            get {
+                return ResourceManager.GetString("ThisUpdateIsRequired", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Three Left.
         /// </summary>
         public static string ThreeLeft {

--- a/MixItUp.Base/Resources.Designer.cs
+++ b/MixItUp.Base/Resources.Designer.cs
@@ -11748,11 +11748,38 @@ namespace MixItUp.Base {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Image Format.
+        /// </summary>
+        public static string ImageFormat {
+            get {
+                return ResourceManager.GetString("ImageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Image Height (Optional).
+        /// </summary>
+        public static string ImageHeightOptional {
+            get {
+                return ResourceManager.GetString("ImageHeightOptional", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Image Source.
         /// </summary>
         public static string ImageSource {
             get {
                 return ResourceManager.GetString("ImageSource", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Image Width (Optional).
+        /// </summary>
+        public static string ImageWidthOptional {
+            get {
+                return ResourceManager.GetString("ImageWidthOptional", resourceCulture);
             }
         }
         
@@ -20468,6 +20495,15 @@ namespace MixItUp.Base {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Save Source Screenshot.
+        /// </summary>
+        public static string SaveSourceScreenshot {
+            get {
+                return ResourceManager.GetString("SaveSourceScreenshot", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Save To File.
         /// </summary>
         public static string SaveToFile {
@@ -22836,6 +22872,15 @@ namespace MixItUp.Base {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to An image format must be specified (e.g. png, jpg).
+        /// </summary>
+        public static string StreamingSoftwareActionMissingImageFormat {
+            get {
+                return ResourceManager.GetString("StreamingSoftwareActionMissingImageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Streaming Software Action: Missing image source file path.
         /// </summary>
         public static string StreamingSoftwareActionMissingImageSourceFilePath {
@@ -22868,6 +22913,15 @@ namespace MixItUp.Base {
         public static string StreamingSoftwareActionMissingSceneCollection {
             get {
                 return ResourceManager.GetString("StreamingSoftwareActionMissingSceneCollection", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to An image file path must be specified to save to.
+        /// </summary>
+        public static string StreamingSoftwareActionMissingScreenshotFilePath {
+            get {
+                return ResourceManager.GetString("StreamingSoftwareActionMissingScreenshotFilePath", resourceCulture);
             }
         }
         

--- a/MixItUp.Base/Resources.de-DE.resx
+++ b/MixItUp.Base/Resources.de-DE.resx
@@ -9972,4 +9972,7 @@ Bitte gehen Sie auf die Seite Konten im Hauptmenü, um Ihr Streaming-Konto zu ve
   <data name="StreamingSoftwareActionMissingScreenshotFilePath" xml:space="preserve">
     <value>Es muss ein Pfad für die Bilddatei angegeben werden, in der gespeichert werden soll</value>
   </data>
+  <data name="ThisUpdateIsRequired" xml:space="preserve">
+    <value>Dieses Update ist erforderlich, um Mix It Up weiterhin nutzen zu können.</value>
+  </data>
 </root>

--- a/MixItUp.Base/Resources.de-DE.resx
+++ b/MixItUp.Base/Resources.de-DE.resx
@@ -9948,4 +9948,10 @@ Bitte gehen Sie auf die Seite Konten im Hauptmenü, um Ihr Streaming-Konto zu ve
   <data name="PopoutEditor" xml:space="preserve">
     <value>Popout-Editor</value>
   </data>
+  <data name="DeleteAllQuotes" xml:space="preserve">
+    <value>Alle Zitate löschen</value>
+  </data>
+  <data name="DeleteAllQuotesWarning" xml:space="preserve">
+    <value>Sind Sie sicher, dass Sie ALLE Zitate löschen wollen? Diese Aktion kann nicht rückgängig gemacht werden</value>
+  </data>
 </root>

--- a/MixItUp.Base/Resources.de-DE.resx
+++ b/MixItUp.Base/Resources.de-DE.resx
@@ -9954,4 +9954,22 @@ Bitte gehen Sie auf die Seite Konten im Hauptmenü, um Ihr Streaming-Konto zu ve
   <data name="DeleteAllQuotesWarning" xml:space="preserve">
     <value>Sind Sie sicher, dass Sie ALLE Zitate löschen wollen? Diese Aktion kann nicht rückgängig gemacht werden</value>
   </data>
+  <data name="SaveSourceScreenshot" xml:space="preserve">
+    <value>Quelle speichern Screenshot</value>
+  </data>
+  <data name="ImageFormat" xml:space="preserve">
+    <value>Bildformat</value>
+  </data>
+  <data name="ImageWidthOptional" xml:space="preserve">
+    <value>Bildbreite (optional)</value>
+  </data>
+  <data name="ImageHeightOptional" xml:space="preserve">
+    <value>Bildhöhe (optional)</value>
+  </data>
+  <data name="StreamingSoftwareActionMissingImageFormat" xml:space="preserve">
+    <value>Es muss ein Bildformat angegeben werden (z. B. png, jpg)</value>
+  </data>
+  <data name="StreamingSoftwareActionMissingScreenshotFilePath" xml:space="preserve">
+    <value>Es muss ein Pfad für die Bilddatei angegeben werden, in der gespeichert werden soll</value>
+  </data>
 </root>

--- a/MixItUp.Base/Resources.de.resx
+++ b/MixItUp.Base/Resources.de.resx
@@ -11235,4 +11235,10 @@ Bitte gehen Sie auf die Seite Konten im Hauptmenü, um Ihr Streaming-Konto zu ve
   <data name="PopoutEditor" xml:space="preserve">
     <value>Popout-Editor</value>
   </data>
+  <data name="DeleteAllQuotes" xml:space="preserve">
+    <value>Alle Zitate löschen</value>
+  </data>
+  <data name="DeleteAllQuotesWarning" xml:space="preserve">
+    <value>Sind Sie sicher, dass Sie ALLE Zitate löschen wollen? Diese Aktion kann nicht rückgängig gemacht werden</value>
+  </data>
 </root>

--- a/MixItUp.Base/Resources.de.resx
+++ b/MixItUp.Base/Resources.de.resx
@@ -11259,4 +11259,7 @@ Bitte gehen Sie auf die Seite Konten im Hauptmenü, um Ihr Streaming-Konto zu ve
   <data name="StreamingSoftwareActionMissingScreenshotFilePath" xml:space="preserve">
     <value>Es muss ein Pfad für die Bilddatei angegeben werden, in der gespeichert werden soll</value>
   </data>
+  <data name="ThisUpdateIsRequired" xml:space="preserve">
+    <value>Dieses Update ist erforderlich, um Mix It Up weiterhin nutzen zu können.</value>
+  </data>
 </root>

--- a/MixItUp.Base/Resources.de.resx
+++ b/MixItUp.Base/Resources.de.resx
@@ -11241,4 +11241,22 @@ Bitte gehen Sie auf die Seite Konten im Hauptmenü, um Ihr Streaming-Konto zu ve
   <data name="DeleteAllQuotesWarning" xml:space="preserve">
     <value>Sind Sie sicher, dass Sie ALLE Zitate löschen wollen? Diese Aktion kann nicht rückgängig gemacht werden</value>
   </data>
+  <data name="SaveSourceScreenshot" xml:space="preserve">
+    <value>Quelle speichern Screenshot</value>
+  </data>
+  <data name="ImageFormat" xml:space="preserve">
+    <value>Bildformat</value>
+  </data>
+  <data name="ImageWidthOptional" xml:space="preserve">
+    <value>Bildbreite (optional)</value>
+  </data>
+  <data name="ImageHeightOptional" xml:space="preserve">
+    <value>Bildhöhe (optional)</value>
+  </data>
+  <data name="StreamingSoftwareActionMissingImageFormat" xml:space="preserve">
+    <value>Es muss ein Bildformat angegeben werden (z. B. png, jpg)</value>
+  </data>
+  <data name="StreamingSoftwareActionMissingScreenshotFilePath" xml:space="preserve">
+    <value>Es muss ein Pfad für die Bilddatei angegeben werden, in der gespeichert werden soll</value>
+  </data>
 </root>

--- a/MixItUp.Base/Resources.es.resx
+++ b/MixItUp.Base/Resources.es.resx
@@ -11231,4 +11231,10 @@ Ve a la página Cuentas del menú principal para conectar tu cuenta de streaming
   <data name="PopoutEditor" xml:space="preserve">
     <value>Editor desplegable</value>
   </data>
+  <data name="DeleteAllQuotes" xml:space="preserve">
+    <value>Borrar todas las citas</value>
+  </data>
+  <data name="DeleteAllQuotesWarning" xml:space="preserve">
+    <value>¿Estás seguro de que quieres borrar TODAS las citas? Esta acción no se puede deshacer</value>
+  </data>
 </root>

--- a/MixItUp.Base/Resources.es.resx
+++ b/MixItUp.Base/Resources.es.resx
@@ -11255,4 +11255,7 @@ Ve a la página Cuentas del menú principal para conectar tu cuenta de streaming
   <data name="StreamingSoftwareActionMissingScreenshotFilePath" xml:space="preserve">
     <value>Debe especificarse una ruta de archivo de imagen para guardar en</value>
   </data>
+  <data name="ThisUpdateIsRequired" xml:space="preserve">
+    <value>Esta actualización es necesaria para seguir utilizando Mix It Up</value>
+  </data>
 </root>

--- a/MixItUp.Base/Resources.es.resx
+++ b/MixItUp.Base/Resources.es.resx
@@ -11237,4 +11237,22 @@ Ve a la página Cuentas del menú principal para conectar tu cuenta de streaming
   <data name="DeleteAllQuotesWarning" xml:space="preserve">
     <value>¿Estás seguro de que quieres borrar TODAS las citas? Esta acción no se puede deshacer</value>
   </data>
+  <data name="SaveSourceScreenshot" xml:space="preserve">
+    <value>Guardar captura de pantalla de origen</value>
+  </data>
+  <data name="ImageFormat" xml:space="preserve">
+    <value>Formato de imagen</value>
+  </data>
+  <data name="ImageWidthOptional" xml:space="preserve">
+    <value>Anchura de la imagen (opcional)</value>
+  </data>
+  <data name="ImageHeightOptional" xml:space="preserve">
+    <value>Altura de la imagen (opcional)</value>
+  </data>
+  <data name="StreamingSoftwareActionMissingImageFormat" xml:space="preserve">
+    <value>Debe especificarse un formato de imagen (por ejemplo, png, jpg)</value>
+  </data>
+  <data name="StreamingSoftwareActionMissingScreenshotFilePath" xml:space="preserve">
+    <value>Debe especificarse una ruta de archivo de imagen para guardar en</value>
+  </data>
 </root>

--- a/MixItUp.Base/Resources.fr.resx
+++ b/MixItUp.Base/Resources.fr.resx
@@ -11230,4 +11230,10 @@ Allez à la page Comptes dans le menu principal pour connecter votre compte de s
   <data name="PopoutEditor" xml:space="preserve">
     <value>Éditeur de fenêtres contextuelles</value>
   </data>
+  <data name="DeleteAllQuotes" xml:space="preserve">
+    <value>Supprimer toutes les citations</value>
+  </data>
+  <data name="DeleteAllQuotesWarning" xml:space="preserve">
+    <value>Êtes-vous sûr de vouloir supprimer TOUTES les citations ? Cette action ne peut être annulée</value>
+  </data>
 </root>

--- a/MixItUp.Base/Resources.fr.resx
+++ b/MixItUp.Base/Resources.fr.resx
@@ -11254,4 +11254,7 @@ Allez à la page Comptes dans le menu principal pour connecter votre compte de s
   <data name="StreamingSoftwareActionMissingScreenshotFilePath" xml:space="preserve">
     <value>Un chemin d'accès au fichier image doit être spécifié pour l'enregistrement.</value>
   </data>
+  <data name="ThisUpdateIsRequired" xml:space="preserve">
+    <value>Cette mise à jour est nécessaire pour continuer à utiliser Mix It Up</value>
+  </data>
 </root>

--- a/MixItUp.Base/Resources.fr.resx
+++ b/MixItUp.Base/Resources.fr.resx
@@ -11236,4 +11236,22 @@ Allez à la page Comptes dans le menu principal pour connecter votre compte de s
   <data name="DeleteAllQuotesWarning" xml:space="preserve">
     <value>Êtes-vous sûr de vouloir supprimer TOUTES les citations ? Cette action ne peut être annulée</value>
   </data>
+  <data name="SaveSourceScreenshot" xml:space="preserve">
+    <value>Sauvegarde de la source Capture d'écran</value>
+  </data>
+  <data name="ImageFormat" xml:space="preserve">
+    <value>Format de l'image</value>
+  </data>
+  <data name="ImageWidthOptional" xml:space="preserve">
+    <value>Largeur de l'image (optionnel)</value>
+  </data>
+  <data name="ImageHeightOptional" xml:space="preserve">
+    <value>Hauteur de l'image (optionnel)</value>
+  </data>
+  <data name="StreamingSoftwareActionMissingImageFormat" xml:space="preserve">
+    <value>Un format d'image doit être spécifié (par exemple, png, jpg).</value>
+  </data>
+  <data name="StreamingSoftwareActionMissingScreenshotFilePath" xml:space="preserve">
+    <value>Un chemin d'accès au fichier image doit être spécifié pour l'enregistrement.</value>
+  </data>
 </root>

--- a/MixItUp.Base/Resources.it.resx
+++ b/MixItUp.Base/Resources.it.resx
@@ -11253,4 +11253,7 @@ Andare alla pagina Account nel menu principale per collegare l'account di stream
   <data name="StreamingSoftwareActionMissingScreenshotFilePath" xml:space="preserve">
     <value>È necessario specificare un percorso per il file immagine da salvare su</value>
   </data>
+  <data name="ThisUpdateIsRequired" xml:space="preserve">
+    <value>Questo aggiornamento è necessario per continuare a utilizzare Mix It Up.</value>
+  </data>
 </root>

--- a/MixItUp.Base/Resources.it.resx
+++ b/MixItUp.Base/Resources.it.resx
@@ -11235,4 +11235,22 @@ Andare alla pagina Account nel menu principale per collegare l'account di stream
   <data name="DeleteAllQuotesWarning" xml:space="preserve">
     <value>Siete sicuri di voler eliminare TUTTE le citazioni? Questa azione non può essere annullata</value>
   </data>
+  <data name="SaveSourceScreenshot" xml:space="preserve">
+    <value>Salva sorgente Schermata</value>
+  </data>
+  <data name="ImageFormat" xml:space="preserve">
+    <value>Formato immagine</value>
+  </data>
+  <data name="ImageWidthOptional" xml:space="preserve">
+    <value>Larghezza immagine (opzionale)</value>
+  </data>
+  <data name="ImageHeightOptional" xml:space="preserve">
+    <value>Altezza immagine (opzionale)</value>
+  </data>
+  <data name="StreamingSoftwareActionMissingImageFormat" xml:space="preserve">
+    <value>È necessario specificare un formato di immagine (ad esempio, png, jpg).</value>
+  </data>
+  <data name="StreamingSoftwareActionMissingScreenshotFilePath" xml:space="preserve">
+    <value>È necessario specificare un percorso per il file immagine da salvare su</value>
+  </data>
 </root>

--- a/MixItUp.Base/Resources.it.resx
+++ b/MixItUp.Base/Resources.it.resx
@@ -11229,4 +11229,10 @@ Andare alla pagina Account nel menu principale per collegare l'account di stream
   <data name="PopoutEditor" xml:space="preserve">
     <value>Editor a comparsa</value>
   </data>
+  <data name="DeleteAllQuotes" xml:space="preserve">
+    <value>Cancellare tutte le citazioni</value>
+  </data>
+  <data name="DeleteAllQuotesWarning" xml:space="preserve">
+    <value>Siete sicuri di voler eliminare TUTTE le citazioni? Questa azione non può essere annullata</value>
+  </data>
 </root>

--- a/MixItUp.Base/Resources.ja.resx
+++ b/MixItUp.Base/Resources.ja.resx
@@ -11229,4 +11229,10 @@ Mix It Upを使用するには、少なくとも1つのストリーミング・�
   <data name="PopoutEditor" xml:space="preserve">
     <value>ポップアウトエディター</value>
   </data>
+  <data name="DeleteAllQuotes" xml:space="preserve">
+    <value>すべての引用符を削除</value>
+  </data>
+  <data name="DeleteAllQuotesWarning" xml:space="preserve">
+    <value>本当にすべての引用符を削除しますか？この操作は元に戻せません。</value>
+  </data>
 </root>

--- a/MixItUp.Base/Resources.ja.resx
+++ b/MixItUp.Base/Resources.ja.resx
@@ -11235,4 +11235,22 @@ Mix It Upを使用するには、少なくとも1つのストリーミング・�
   <data name="DeleteAllQuotesWarning" xml:space="preserve">
     <value>本当にすべての引用符を削除しますか？この操作は元に戻せません。</value>
   </data>
+  <data name="SaveSourceScreenshot" xml:space="preserve">
+    <value>ソースのスクリーンショットを保存</value>
+  </data>
+  <data name="ImageFormat" xml:space="preserve">
+    <value>画像フォーマット</value>
+  </data>
+  <data name="ImageWidthOptional" xml:space="preserve">
+    <value>画像の幅（オプション）</value>
+  </data>
+  <data name="ImageHeightOptional" xml:space="preserve">
+    <value>画像の高さ（オプション）</value>
+  </data>
+  <data name="StreamingSoftwareActionMissingImageFormat" xml:space="preserve">
+    <value>画像フォーマットを指定する必要があります（例：png、jpg）。</value>
+  </data>
+  <data name="StreamingSoftwareActionMissingScreenshotFilePath" xml:space="preserve">
+    <value>保存先の画像ファイルのパスを指定する必要があります。</value>
+  </data>
 </root>

--- a/MixItUp.Base/Resources.ja.resx
+++ b/MixItUp.Base/Resources.ja.resx
@@ -11253,4 +11253,7 @@ Mix It Upを使用するには、少なくとも1つのストリーミング・�
   <data name="StreamingSoftwareActionMissingScreenshotFilePath" xml:space="preserve">
     <value>保存先の画像ファイルのパスを指定する必要があります。</value>
   </data>
+  <data name="ThisUpdateIsRequired" xml:space="preserve">
+    <value>このアップデートは、Mix It Upを使用し続けるために必要です。</value>
+  </data>
 </root>

--- a/MixItUp.Base/Resources.nl.resx
+++ b/MixItUp.Base/Resources.nl.resx
@@ -11230,4 +11230,10 @@ Ga naar de pagina Accounts in het hoofdmenu om je streamingaccount aan te sluite
   <data name="PopoutEditor" xml:space="preserve">
     <value>Popout-editor</value>
   </data>
+  <data name="DeleteAllQuotes" xml:space="preserve">
+    <value>Alle citaten verwijderen</value>
+  </data>
+  <data name="DeleteAllQuotesWarning" xml:space="preserve">
+    <value>Weet je zeker dat je ALLE citaten wilt verwijderen? Deze actie kan niet ongedaan worden gemaakt</value>
+  </data>
 </root>

--- a/MixItUp.Base/Resources.nl.resx
+++ b/MixItUp.Base/Resources.nl.resx
@@ -11254,4 +11254,7 @@ Ga naar de pagina Accounts in het hoofdmenu om je streamingaccount aan te sluite
   <data name="StreamingSoftwareActionMissingScreenshotFilePath" xml:space="preserve">
     <value>Er moet een pad naar een afbeeldingsbestand worden opgegeven om op te slaan in</value>
   </data>
+  <data name="ThisUpdateIsRequired" xml:space="preserve">
+    <value>Deze update is vereist om Mix It Up te kunnen blijven gebruiken</value>
+  </data>
 </root>

--- a/MixItUp.Base/Resources.nl.resx
+++ b/MixItUp.Base/Resources.nl.resx
@@ -11236,4 +11236,22 @@ Ga naar de pagina Accounts in het hoofdmenu om je streamingaccount aan te sluite
   <data name="DeleteAllQuotesWarning" xml:space="preserve">
     <value>Weet je zeker dat je ALLE citaten wilt verwijderen? Deze actie kan niet ongedaan worden gemaakt</value>
   </data>
+  <data name="SaveSourceScreenshot" xml:space="preserve">
+    <value>Bron screenshot opslaan</value>
+  </data>
+  <data name="ImageFormat" xml:space="preserve">
+    <value>Afbeeldingsformaat</value>
+  </data>
+  <data name="ImageWidthOptional" xml:space="preserve">
+    <value>Breedte afbeelding (optioneel)</value>
+  </data>
+  <data name="ImageHeightOptional" xml:space="preserve">
+    <value>Hoogte afbeelding (optioneel)</value>
+  </data>
+  <data name="StreamingSoftwareActionMissingImageFormat" xml:space="preserve">
+    <value>Er moet een afbeeldingsformaat worden opgegeven (bijv. png, jpg)</value>
+  </data>
+  <data name="StreamingSoftwareActionMissingScreenshotFilePath" xml:space="preserve">
+    <value>Er moet een pad naar een afbeeldingsbestand worden opgegeven om op te slaan in</value>
+  </data>
 </root>

--- a/MixItUp.Base/Resources.pl.resx
+++ b/MixItUp.Base/Resources.pl.resx
@@ -11229,4 +11229,10 @@ Przejdź do strony Konta w menu głównym, aby połączyć swoje konto streaming
   <data name="PopoutEditor" xml:space="preserve">
     <value>Edytor wyskakujących okienek</value>
   </data>
+  <data name="DeleteAllQuotes" xml:space="preserve">
+    <value>Usuń wszystkie cytaty</value>
+  </data>
+  <data name="DeleteAllQuotesWarning" xml:space="preserve">
+    <value>Czy na pewno chcesz usunąć WSZYSTKIE cudzysłowy? Tej czynności nie można cofnąć</value>
+  </data>
 </root>

--- a/MixItUp.Base/Resources.pl.resx
+++ b/MixItUp.Base/Resources.pl.resx
@@ -11253,4 +11253,7 @@ Przejdź do strony Konta w menu głównym, aby połączyć swoje konto streaming
   <data name="StreamingSoftwareActionMissingScreenshotFilePath" xml:space="preserve">
     <value>Ścieżka do pliku obrazu musi być określona, aby zapisać go w pliku</value>
   </data>
+  <data name="ThisUpdateIsRequired" xml:space="preserve">
+    <value>Ta aktualizacja jest wymagana do dalszego korzystania z Mix It Up</value>
+  </data>
 </root>

--- a/MixItUp.Base/Resources.pl.resx
+++ b/MixItUp.Base/Resources.pl.resx
@@ -11235,4 +11235,22 @@ Przejdź do strony Konta w menu głównym, aby połączyć swoje konto streaming
   <data name="DeleteAllQuotesWarning" xml:space="preserve">
     <value>Czy na pewno chcesz usunąć WSZYSTKIE cudzysłowy? Tej czynności nie można cofnąć</value>
   </data>
+  <data name="SaveSourceScreenshot" xml:space="preserve">
+    <value>Zapisz zrzut ekranu źródła</value>
+  </data>
+  <data name="ImageFormat" xml:space="preserve">
+    <value>Format obrazu</value>
+  </data>
+  <data name="ImageWidthOptional" xml:space="preserve">
+    <value>Szerokość obrazu (opcjonalnie)</value>
+  </data>
+  <data name="ImageHeightOptional" xml:space="preserve">
+    <value>Wysokość obrazu (opcjonalnie)</value>
+  </data>
+  <data name="StreamingSoftwareActionMissingImageFormat" xml:space="preserve">
+    <value>Należy określić format obrazu (np. png, jpg).</value>
+  </data>
+  <data name="StreamingSoftwareActionMissingScreenshotFilePath" xml:space="preserve">
+    <value>Ścieżka do pliku obrazu musi być określona, aby zapisać go w pliku</value>
+  </data>
 </root>

--- a/MixItUp.Base/Resources.pt-BR.resx
+++ b/MixItUp.Base/Resources.pt-BR.resx
@@ -11254,4 +11254,7 @@ Aceda à página Contas no menu principal para ligar a sua conta de transmissão
   <data name="StreamingSoftwareActionMissingScreenshotFilePath" xml:space="preserve">
     <value>Deve ser especificado um caminho para o ficheiro de imagem a guardar</value>
   </data>
+  <data name="ThisUpdateIsRequired" xml:space="preserve">
+    <value>Esta atualização é necessária para continuar a utilizar o Mix It Up</value>
+  </data>
 </root>

--- a/MixItUp.Base/Resources.pt-BR.resx
+++ b/MixItUp.Base/Resources.pt-BR.resx
@@ -11236,4 +11236,22 @@ Aceda à página Contas no menu principal para ligar a sua conta de transmissão
   <data name="DeleteAllQuotesWarning" xml:space="preserve">
     <value>Tem a certeza de que pretende apagar TODAS as aspas? Esta ação não pode ser anulada</value>
   </data>
+  <data name="SaveSourceScreenshot" xml:space="preserve">
+    <value>Guardar a captura de ecrã da fonte</value>
+  </data>
+  <data name="ImageFormat" xml:space="preserve">
+    <value>Formato da imagem</value>
+  </data>
+  <data name="ImageWidthOptional" xml:space="preserve">
+    <value>Largura da imagem (opcional)</value>
+  </data>
+  <data name="ImageHeightOptional" xml:space="preserve">
+    <value>Altura da imagem (opcional)</value>
+  </data>
+  <data name="StreamingSoftwareActionMissingImageFormat" xml:space="preserve">
+    <value>Deve ser especificado um formato de imagem (por exemplo, png, jpg)</value>
+  </data>
+  <data name="StreamingSoftwareActionMissingScreenshotFilePath" xml:space="preserve">
+    <value>Deve ser especificado um caminho para o ficheiro de imagem a guardar</value>
+  </data>
 </root>

--- a/MixItUp.Base/Resources.pt-BR.resx
+++ b/MixItUp.Base/Resources.pt-BR.resx
@@ -11230,4 +11230,10 @@ Aceda à página Contas no menu principal para ligar a sua conta de transmissão
   <data name="PopoutEditor" xml:space="preserve">
     <value>Editor de popout</value>
   </data>
+  <data name="DeleteAllQuotes" xml:space="preserve">
+    <value>Apagar todas as citações</value>
+  </data>
+  <data name="DeleteAllQuotesWarning" xml:space="preserve">
+    <value>Tem a certeza de que pretende apagar TODAS as aspas? Esta ação não pode ser anulada</value>
+  </data>
 </root>

--- a/MixItUp.Base/Resources.pt-PT.resx
+++ b/MixItUp.Base/Resources.pt-PT.resx
@@ -11255,4 +11255,7 @@ Aceda à página Contas no menu principal para ligar a sua conta de transmissão
   <data name="StreamingSoftwareActionMissingScreenshotFilePath" xml:space="preserve">
     <value>Deve ser especificado um caminho para o ficheiro de imagem a guardar</value>
   </data>
+  <data name="ThisUpdateIsRequired" xml:space="preserve">
+    <value>Esta atualização é necessária para continuar a utilizar o Mix It Up</value>
+  </data>
 </root>

--- a/MixItUp.Base/Resources.pt-PT.resx
+++ b/MixItUp.Base/Resources.pt-PT.resx
@@ -11237,4 +11237,22 @@ Aceda à página Contas no menu principal para ligar a sua conta de transmissão
   <data name="DeleteAllQuotesWarning" xml:space="preserve">
     <value>Tem a certeza de que pretende apagar TODAS as aspas? Esta ação não pode ser anulada</value>
   </data>
+  <data name="SaveSourceScreenshot" xml:space="preserve">
+    <value>Guardar a captura de ecrã da fonte</value>
+  </data>
+  <data name="ImageFormat" xml:space="preserve">
+    <value>Formato da imagem</value>
+  </data>
+  <data name="ImageWidthOptional" xml:space="preserve">
+    <value>Largura da imagem (opcional)</value>
+  </data>
+  <data name="ImageHeightOptional" xml:space="preserve">
+    <value>Altura da imagem (opcional)</value>
+  </data>
+  <data name="StreamingSoftwareActionMissingImageFormat" xml:space="preserve">
+    <value>Deve ser especificado um formato de imagem (por exemplo, png, jpg)</value>
+  </data>
+  <data name="StreamingSoftwareActionMissingScreenshotFilePath" xml:space="preserve">
+    <value>Deve ser especificado um caminho para o ficheiro de imagem a guardar</value>
+  </data>
 </root>

--- a/MixItUp.Base/Resources.pt-PT.resx
+++ b/MixItUp.Base/Resources.pt-PT.resx
@@ -11231,4 +11231,10 @@ Aceda à página Contas no menu principal para ligar a sua conta de transmissão
   <data name="PopoutEditor" xml:space="preserve">
     <value>Editor de popout</value>
   </data>
+  <data name="DeleteAllQuotes" xml:space="preserve">
+    <value>Apagar todas as citações</value>
+  </data>
+  <data name="DeleteAllQuotesWarning" xml:space="preserve">
+    <value>Tem a certeza de que pretende apagar TODAS as aspas? Esta ação não pode ser anulada</value>
+  </data>
 </root>

--- a/MixItUp.Base/Resources.qps-ploc.resx
+++ b/MixItUp.Base/Resources.qps-ploc.resx
@@ -11235,4 +11235,22 @@ Please go to the Accounts page in the main menu to connect your streaming accoun
   <data name="DeleteAllQuotesWarning" xml:space="preserve">
     <value>Are you sure you want to delete ALL quotes? This action cannot be undone</value>
   </data>
+  <data name="SaveSourceScreenshot" xml:space="preserve">
+    <value>Save Source Screenshot</value>
+  </data>
+  <data name="ImageFormat" xml:space="preserve">
+    <value>Image Format</value>
+  </data>
+  <data name="ImageWidthOptional" xml:space="preserve">
+    <value>Image Width (Optional)</value>
+  </data>
+  <data name="ImageHeightOptional" xml:space="preserve">
+    <value>Image Height (Optional)</value>
+  </data>
+  <data name="StreamingSoftwareActionMissingImageFormat" xml:space="preserve">
+    <value>An image format must be specified (e.g. png, jpg)</value>
+  </data>
+  <data name="StreamingSoftwareActionMissingScreenshotFilePath" xml:space="preserve">
+    <value>An image file path must be specified to save to</value>
+  </data>
 </root>

--- a/MixItUp.Base/Resources.qps-ploc.resx
+++ b/MixItUp.Base/Resources.qps-ploc.resx
@@ -11253,4 +11253,7 @@ Please go to the Accounts page in the main menu to connect your streaming accoun
   <data name="StreamingSoftwareActionMissingScreenshotFilePath" xml:space="preserve">
     <value>An image file path must be specified to save to</value>
   </data>
+  <data name="ThisUpdateIsRequired" xml:space="preserve">
+    <value>This update is required to continue using Mix It Up</value>
+  </data>
 </root>

--- a/MixItUp.Base/Resources.qps-ploc.resx
+++ b/MixItUp.Base/Resources.qps-ploc.resx
@@ -11229,4 +11229,10 @@ Please go to the Accounts page in the main menu to connect your streaming accoun
   <data name="PopoutEditor" xml:space="preserve">
     <value>Popout Editor</value>
   </data>
+  <data name="DeleteAllQuotes" xml:space="preserve">
+    <value>Delete All Quotes</value>
+  </data>
+  <data name="DeleteAllQuotesWarning" xml:space="preserve">
+    <value>Are you sure you want to delete ALL quotes? This action cannot be undone</value>
+  </data>
 </root>

--- a/MixItUp.Base/Resources.resx
+++ b/MixItUp.Base/Resources.resx
@@ -11235,4 +11235,10 @@ Please go to the Accounts page in the main menu to connect your streaming accoun
   <data name="PopoutEditor" xml:space="preserve">
     <value>Popout Editor</value>
   </data>
+  <data name="DeleteAllQuotes" xml:space="preserve">
+    <value>Delete All Quotes</value>
+  </data>
+  <data name="DeleteAllQuotesWarning" xml:space="preserve">
+    <value>Are you sure you want to delete ALL quotes? This action cannot be undone</value>
+  </data>
 </root>

--- a/MixItUp.Base/Resources.resx
+++ b/MixItUp.Base/Resources.resx
@@ -11259,4 +11259,7 @@ Please go to the Accounts page in the main menu to connect your streaming accoun
   <data name="StreamingSoftwareActionMissingScreenshotFilePath" xml:space="preserve">
     <value>An image file path must be specified to save to</value>
   </data>
+  <data name="ThisUpdateIsRequired" xml:space="preserve">
+    <value>This update is required to continue using Mix It Up</value>
+  </data>
 </root>

--- a/MixItUp.Base/Resources.resx
+++ b/MixItUp.Base/Resources.resx
@@ -11241,4 +11241,22 @@ Please go to the Accounts page in the main menu to connect your streaming accoun
   <data name="DeleteAllQuotesWarning" xml:space="preserve">
     <value>Are you sure you want to delete ALL quotes? This action cannot be undone</value>
   </data>
+  <data name="SaveSourceScreenshot" xml:space="preserve">
+    <value>Save Source Screenshot</value>
+  </data>
+  <data name="ImageFormat" xml:space="preserve">
+    <value>Image Format</value>
+  </data>
+  <data name="ImageWidthOptional" xml:space="preserve">
+    <value>Image Width (Optional)</value>
+  </data>
+  <data name="ImageHeightOptional" xml:space="preserve">
+    <value>Image Height (Optional)</value>
+  </data>
+  <data name="StreamingSoftwareActionMissingImageFormat" xml:space="preserve">
+    <value>An image format must be specified (e.g. png, jpg)</value>
+  </data>
+  <data name="StreamingSoftwareActionMissingScreenshotFilePath" xml:space="preserve">
+    <value>An image file path must be specified to save to</value>
+  </data>
 </root>

--- a/MixItUp.Base/Resources.ru.resx
+++ b/MixItUp.Base/Resources.ru.resx
@@ -11234,4 +11234,10 @@ sendParentMessage({ Тип: "ScriptComplete", ID: "{ID}", Результат: р
   <data name="PopoutEditor" xml:space="preserve">
     <value>Выпадающий редактор</value>
   </data>
+  <data name="DeleteAllQuotes" xml:space="preserve">
+    <value>Удалить все цитаты</value>
+  </data>
+  <data name="DeleteAllQuotesWarning" xml:space="preserve">
+    <value>Вы уверены, что хотите удалить ВСЕ цитаты? Это действие нельзя отменить</value>
+  </data>
 </root>

--- a/MixItUp.Base/Resources.ru.resx
+++ b/MixItUp.Base/Resources.ru.resx
@@ -11240,4 +11240,22 @@ sendParentMessage({ Тип: "ScriptComplete", ID: "{ID}", Результат: р
   <data name="DeleteAllQuotesWarning" xml:space="preserve">
     <value>Вы уверены, что хотите удалить ВСЕ цитаты? Это действие нельзя отменить</value>
   </data>
+  <data name="SaveSourceScreenshot" xml:space="preserve">
+    <value>Сохранить скриншот источника</value>
+  </data>
+  <data name="ImageFormat" xml:space="preserve">
+    <value>Формат изображения</value>
+  </data>
+  <data name="ImageWidthOptional" xml:space="preserve">
+    <value>Ширина изображения (дополнительно)</value>
+  </data>
+  <data name="ImageHeightOptional" xml:space="preserve">
+    <value>Высота изображения (опционально)</value>
+  </data>
+  <data name="StreamingSoftwareActionMissingImageFormat" xml:space="preserve">
+    <value>Необходимо указать формат изображения (например, png, jpg)</value>
+  </data>
+  <data name="StreamingSoftwareActionMissingScreenshotFilePath" xml:space="preserve">
+    <value>Для сохранения необходимо указать путь к файлу изображения</value>
+  </data>
 </root>

--- a/MixItUp.Base/Resources.ru.resx
+++ b/MixItUp.Base/Resources.ru.resx
@@ -11258,4 +11258,7 @@ sendParentMessage({ Тип: "ScriptComplete", ID: "{ID}", Результат: р
   <data name="StreamingSoftwareActionMissingScreenshotFilePath" xml:space="preserve">
     <value>Для сохранения необходимо указать путь к файлу изображения</value>
   </data>
+  <data name="ThisUpdateIsRequired" xml:space="preserve">
+    <value>Это обновление необходимо для продолжения использования Mix It Up</value>
+  </data>
 </root>

--- a/MixItUp.Base/Resources.uk.resx
+++ b/MixItUp.Base/Resources.uk.resx
@@ -11229,4 +11229,10 @@ print(run())</value>
   <data name="PopoutEditor" xml:space="preserve">
     <value>Редактор витікання</value>
   </data>
+  <data name="DeleteAllQuotes" xml:space="preserve">
+    <value>Видалити всі цитати</value>
+  </data>
+  <data name="DeleteAllQuotesWarning" xml:space="preserve">
+    <value>Ви впевнені, що хочете видалити ВСІ лапки? Ця дія не може бути скасована</value>
+  </data>
 </root>

--- a/MixItUp.Base/Resources.uk.resx
+++ b/MixItUp.Base/Resources.uk.resx
@@ -11253,4 +11253,7 @@ print(run())</value>
   <data name="StreamingSoftwareActionMissingScreenshotFilePath" xml:space="preserve">
     <value>Необхідно вказати шлях до файлу зображення для збереження</value>
   </data>
+  <data name="ThisUpdateIsRequired" xml:space="preserve">
+    <value>Це оновлення необхідне для продовження використання Mix It Up</value>
+  </data>
 </root>

--- a/MixItUp.Base/Resources.uk.resx
+++ b/MixItUp.Base/Resources.uk.resx
@@ -11235,4 +11235,22 @@ print(run())</value>
   <data name="DeleteAllQuotesWarning" xml:space="preserve">
     <value>Ви впевнені, що хочете видалити ВСІ лапки? Ця дія не може бути скасована</value>
   </data>
+  <data name="SaveSourceScreenshot" xml:space="preserve">
+    <value>Зберегти вихідний знімок екрана</value>
+  </data>
+  <data name="ImageFormat" xml:space="preserve">
+    <value>Формат зображення</value>
+  </data>
+  <data name="ImageWidthOptional" xml:space="preserve">
+    <value>Ширина зображення (необов'язково)</value>
+  </data>
+  <data name="ImageHeightOptional" xml:space="preserve">
+    <value>Висота зображення (необов'язково)</value>
+  </data>
+  <data name="StreamingSoftwareActionMissingImageFormat" xml:space="preserve">
+    <value>Необхідно вказати формат зображення (наприклад, png, jpg)</value>
+  </data>
+  <data name="StreamingSoftwareActionMissingScreenshotFilePath" xml:space="preserve">
+    <value>Необхідно вказати шлях до файлу зображення для збереження</value>
+  </data>
 </root>

--- a/MixItUp.Base/Resources.zh-TW.resx
+++ b/MixItUp.Base/Resources.zh-TW.resx
@@ -11253,4 +11253,7 @@ sendParentMessage({ 型別: "ScriptComplete", ID: "{ID}", 結果: 結果 });</va
   <data name="StreamingSoftwareActionMissingScreenshotFilePath" xml:space="preserve">
     <value>必须指定图像文件路径，以便保存到</value>
   </data>
+  <data name="ThisUpdateIsRequired" xml:space="preserve">
+    <value>要继续使用 Mix It Up，必须进行此更新</value>
+  </data>
 </root>

--- a/MixItUp.Base/Resources.zh-TW.resx
+++ b/MixItUp.Base/Resources.zh-TW.resx
@@ -11229,4 +11229,10 @@ sendParentMessage({ 型別: "ScriptComplete", ID: "{ID}", 結果: 結果 });</va
   <data name="PopoutEditor" xml:space="preserve">
     <value>弹出编辑器</value>
   </data>
+  <data name="DeleteAllQuotes" xml:space="preserve">
+    <value>删除所有报价</value>
+  </data>
+  <data name="DeleteAllQuotesWarning" xml:space="preserve">
+    <value>您确定要删除所有引号吗？此操作无法撤销</value>
+  </data>
 </root>

--- a/MixItUp.Base/Resources.zh-TW.resx
+++ b/MixItUp.Base/Resources.zh-TW.resx
@@ -11235,4 +11235,22 @@ sendParentMessage({ 型別: "ScriptComplete", ID: "{ID}", 結果: 結果 });</va
   <data name="DeleteAllQuotesWarning" xml:space="preserve">
     <value>您确定要删除所有引号吗？此操作无法撤销</value>
   </data>
+  <data name="SaveSourceScreenshot" xml:space="preserve">
+    <value>保存源截图</value>
+  </data>
+  <data name="ImageFormat" xml:space="preserve">
+    <value>图像格式</value>
+  </data>
+  <data name="ImageWidthOptional" xml:space="preserve">
+    <value>图像宽度（可选）</value>
+  </data>
+  <data name="ImageHeightOptional" xml:space="preserve">
+    <value>图像高度（可选）</value>
+  </data>
+  <data name="StreamingSoftwareActionMissingImageFormat" xml:space="preserve">
+    <value>必须指定图像格式（如 png、jpg）</value>
+  </data>
+  <data name="StreamingSoftwareActionMissingScreenshotFilePath" xml:space="preserve">
+    <value>必须指定图像文件路径，以便保存到</value>
+  </data>
 </root>

--- a/MixItUp.Base/Services/External/IStreamingSoftwareService.cs
+++ b/MixItUp.Base/Services/External/IStreamingSoftwareService.cs
@@ -31,6 +31,8 @@ namespace MixItUp.Base.Services.External
         Task<bool> StartReplayBuffer();
 
         Task SetSceneCollection(string sceneCollectionName);
+
+        Task SaveSourceScreenshot(string sourceName, string imageFormat, string imageFilePath, int? imageWidth, int? imageHeight);
     }
 
     public interface IOBSStudioService : IStreamingSoftwareService

--- a/MixItUp.Base/Services/External/StreamlabsDesktopService.cs
+++ b/MixItUp.Base/Services/External/StreamlabsDesktopService.cs
@@ -225,8 +225,8 @@ namespace MixItUp.Base.Services.External
 
         public async Task SetSourceVisibility(string sceneName, string sourceName, bool visibility)
         {
-            StreamlabsOBSSceneItem sceneItem = await this.GetSceneItem(sceneName, sourceName);
-            if (sceneItem != null)
+            IEnumerable<StreamlabsOBSSceneItem> sceneItems = await this.GetSceneItems(sceneName, sourceName);
+            foreach (StreamlabsOBSSceneItem sceneItem in sceneItems)
             {
                 StreamlabsOBSRequest request = new StreamlabsOBSRequest("setVisibility", sceneItem.ResourceID);
                 request.Arguments.Add(visibility);
@@ -238,8 +238,8 @@ namespace MixItUp.Base.Services.External
 
         public async Task SetImageSourceFilePath(string sceneName, string sourceName, string filePath)
         {
-            StreamlabsOBSSceneItem sceneItem = await this.GetSceneItem(sceneName, sourceName);
-            if (sceneItem != null)
+            IEnumerable<StreamlabsOBSSceneItem> sceneItems = await this.GetSceneItems(sceneName, sourceName);
+            foreach (StreamlabsOBSSceneItem sceneItem in sceneItems)
             {
                 StreamlabsOBSSource source = await this.GetItemSource(sceneItem);
                 if (source != null && source.Type.Equals("image_source"))
@@ -261,8 +261,8 @@ namespace MixItUp.Base.Services.External
 
         public async Task SetMediaSourceFilePath(string sceneName, string sourceName, string filePath)
         {
-            StreamlabsOBSSceneItem sceneItem = await this.GetSceneItem(sceneName, sourceName);
-            if (sceneItem != null)
+            IEnumerable<StreamlabsOBSSceneItem> sceneItems = await this.GetSceneItems(sceneName, sourceName);
+            foreach (StreamlabsOBSSceneItem sceneItem in sceneItems)
             {
                 StreamlabsOBSSource source = await this.GetItemSource(sceneItem);
                 if (source != null && source.Type.Equals("ffmpeg_source"))
@@ -284,8 +284,8 @@ namespace MixItUp.Base.Services.External
 
         public async Task SetWebBrowserSourceURL(string sceneName, string sourceName, string url)
         {
-            StreamlabsOBSSceneItem sceneItem = await this.GetSceneItem(sceneName, sourceName);
-            if (sceneItem != null)
+            IEnumerable<StreamlabsOBSSceneItem> sceneItems = await this.GetSceneItems(sceneName, sourceName);
+            foreach (StreamlabsOBSSceneItem sceneItem in sceneItems)
             {
                 StreamlabsOBSSource source = await this.GetItemSource(sceneItem);
                 if (source != null && source.Type.Equals("browser_source"))
@@ -359,6 +359,8 @@ namespace MixItUp.Base.Services.External
             return true;
         }
 
+        public Task SaveSourceScreenshot(string sourceName, string imageFormat, string imageFilePath, int? imageWidth, int? imageHeight) { return Task.CompletedTask; }
+
         public Task SetSceneCollection(string sceneCollectionName) { return Task.CompletedTask; }
 
         private async Task<StreamlabsOBSScene> GetActiveScene()
@@ -372,15 +374,21 @@ namespace MixItUp.Base.Services.External
             return scenes.FirstOrDefault(s => s.Name.Equals(sceneName));
         }
 
-        private async Task<StreamlabsOBSSceneItem> GetSceneItem(string sceneName, string sourceName)
+        private async Task<IEnumerable<StreamlabsOBSSceneItem>> GetSceneItems(string sceneName, string sourceName)
         {
             StreamlabsOBSScene scene = (!string.IsNullOrEmpty(sceneName)) ? await this.GetScene(sceneName) : await this.GetActiveScene();
             if (scene != null)
             {
                 IEnumerable<StreamlabsOBSSceneItem> sceneItems = await this.GetArrayResult<StreamlabsOBSSceneItem>(new StreamlabsOBSRequest("getItems", scene.ResourceID));
-                return sceneItems.FirstOrDefault(s => s.Name.Equals(sourceName));
+                return sceneItems.Where(s => s.Name.Equals(sourceName));
             }
-            return null;
+            return new List<StreamlabsOBSSceneItem>();
+        }
+
+        private async Task<StreamlabsOBSSceneItem> GetSceneItem(string sceneName, string sourceName)
+        {
+            IEnumerable<StreamlabsOBSSceneItem> items = await this.GetSceneItems(sceneName, sourceName);
+            return items.FirstOrDefault();
         }
 
         private async Task<StreamlabsOBSSource> GetItemSource(StreamlabsOBSSceneItem sceneItem)

--- a/MixItUp.Base/Services/External/XSplitService.cs
+++ b/MixItUp.Base/Services/External/XSplitService.cs
@@ -161,6 +161,8 @@ namespace MixItUp.Base.Services.External
         public Task SaveReplayBuffer() { return Task.CompletedTask; }
         public Task<bool> StartReplayBuffer() { return Task.FromResult(false); }
 
+        public Task SaveSourceScreenshot(string sourceName, string imageFormat, string imageFilePath, int? imageWidth, int? imageHeight) { return Task.CompletedTask; }
+
         public Task SetSceneCollection(string sceneCollectionName) { return Task.CompletedTask; }
 
         protected override WebSocketServerBase CreateWebSocketServer(HttpListenerContext listenerContext)

--- a/MixItUp.Base/Services/Twitch/New/TwitchSession.cs
+++ b/MixItUp.Base/Services/Twitch/New/TwitchSession.cs
@@ -735,6 +735,18 @@ namespace MixItUp.Base.Services.Twitch.New
                 }
             }
 
+            if (giftedSubEvent.Gifter != null && !giftedSubEvent.IsAnonymous)
+            {
+                if (giftedSubEvent.CumulativeGifts.HasValue)
+                {
+                    giftedSubEvent.Gifter.TotalSubsGifted = giftedSubEvent.CumulativeGifts.Value;
+                }
+                else
+                {
+                    giftedSubEvent.Gifter.TotalSubsGifted++;
+                }
+            }
+
             if (fireEventCommand)
             {
                 CommandParametersModel parameters = new CommandParametersModel(giftedSubEvent.Gifter, StreamingPlatformTypeEnum.Twitch);
@@ -758,7 +770,7 @@ namespace MixItUp.Base.Services.Twitch.New
             CommandParametersModel parameters = new CommandParametersModel(massGiftedSubEvent.Gifter, StreamingPlatformTypeEnum.Twitch);
             parameters.SpecialIdentifiers["subsgiftedamount"] = massGiftedSubEvent.TotalGifted.ToString();
             parameters.SpecialIdentifiers["substotalpoints"] = massGiftedSubEvent.TotalSubPoints.ToString();
-            parameters.SpecialIdentifiers["subsgiftedlifetimeamount"] = massGiftedSubEvent.LifetimeGifted.ToString();
+            parameters.SpecialIdentifiers["subsgiftedlifetimeamount"] = massGiftedSubEvent.LifetimeGifted.GetValueOrDefault().ToString();
             parameters.SpecialIdentifiers["usersubplan"] = massGiftedSubEvent.TierName;
             parameters.SpecialIdentifiers["isanonymous"] = massGiftedSubEvent.IsAnonymous.ToString();
 
@@ -772,9 +784,9 @@ namespace MixItUp.Base.Services.Twitch.New
                 parameters.Arguments.Add(sub.User.Username);
             }
 
-            if (!massGiftedSubEvent.IsAnonymous)
+            if (!massGiftedSubEvent.IsAnonymous && massGiftedSubEvent.LifetimeGifted.HasValue)
             {
-                massGiftedSubEvent.Gifter.TotalSubsGifted = (uint)massGiftedSubEvent.LifetimeGifted;
+                massGiftedSubEvent.Gifter.TotalSubsGifted = massGiftedSubEvent.LifetimeGifted.Value;
             }
 
             await ServiceManager.Get<EventService>().PerformEvent(EventTypeEnum.TwitchChannelMassSubscriptionsGifted, parameters);

--- a/MixItUp.Base/ViewModel/Actions/StreamingSoftwareActionEditorControlViewModel.cs
+++ b/MixItUp.Base/ViewModel/Actions/StreamingSoftwareActionEditorControlViewModel.cs
@@ -50,6 +50,8 @@ namespace MixItUp.Base.ViewModel.Actions
                 this.NotifyPropertyChanged("ShowWebBrowserSourceGrid");
                 this.NotifyPropertyChanged("ShowSourceDimensionsGrid");
                 this.NotifyPropertyChanged("ShowSourceFilterGrid");
+                this.NotifyPropertyChanged("ShowSaveSourceScreenshotGrid");
+                this.NotifyPropertyChanged("ShowSourceVisibilityToggle");
             }
         }
         private StreamingSoftwareActionTypeEnum selectedActionType;
@@ -121,6 +123,13 @@ namespace MixItUp.Base.ViewModel.Actions
                         return true;
                     }
                 }
+                else if (this.SelectedActionType == StreamingSoftwareActionTypeEnum.SaveSourceScreenshot)
+                {
+                    if (streamingSoftware == StreamingSoftwareTypeEnum.XSplit || streamingSoftware == StreamingSoftwareTypeEnum.StreamlabsDesktop)
+                    {
+                        return true;
+                    }
+                }
                 return false;
             }
         }
@@ -151,12 +160,20 @@ namespace MixItUp.Base.ViewModel.Actions
         }
         private string sceneName;
 
+        public bool ShowSourceVisibilityToggle
+        {
+            get
+            {
+                return this.SelectedActionType != StreamingSoftwareActionTypeEnum.SaveSourceScreenshot;
+            }
+        }
+
         public bool ShowSourceGrid
         {
             get
             {
                 return this.SelectedActionType == StreamingSoftwareActionTypeEnum.SourceVisibility || this.ShowTextSourceGrid || this.ShowImageSourceGrid ||
-                    this.ShowMediaSourceGrid || this.ShowWebBrowserSourceGrid || this.ShowSourceDimensionsGrid;
+                    this.ShowMediaSourceGrid || this.ShowWebBrowserSourceGrid || this.ShowSourceDimensionsGrid || this.ShowSaveSourceScreenshotGrid;
             }
         }
 
@@ -260,6 +277,52 @@ namespace MixItUp.Base.ViewModel.Actions
         private string sourceWebPageFilePath;
 
         public bool ShowSourceDimensionsGrid { get { return this.SelectedActionType == StreamingSoftwareActionTypeEnum.SourceDimensions; } }
+
+        public bool ShowSaveSourceScreenshotGrid { get { return this.SelectedActionType == StreamingSoftwareActionTypeEnum.SaveSourceScreenshot; } }
+
+        public string ImageFormat
+        {
+            get { return this.imageFormat; }
+            set
+            {
+                this.imageFormat = value;
+                this.NotifyPropertyChanged();
+            }
+        }
+        private string imageFormat = "png";
+
+        public string ImageFilePath
+        {
+            get { return this.imageFilePath; }
+            set
+            {
+                this.imageFilePath = value;
+                this.NotifyPropertyChanged();
+            }
+        }
+        private string imageFilePath;
+
+        public int? ImageWidth
+        {
+            get { return this.imageWidth; }
+            set
+            {
+                this.imageWidth = value;
+                this.NotifyPropertyChanged();
+            }
+        }
+        private int? imageWidth;
+
+        public int? ImageHeight
+        {
+            get { return this.imageHeight; }
+            set
+            {
+                this.imageHeight = value;
+                this.NotifyPropertyChanged();
+            }
+        }
+        private int? imageHeight;
 
         public int SourceXPosition
         {
@@ -377,6 +440,13 @@ namespace MixItUp.Base.ViewModel.Actions
                 {
                     this.SourceWebPageFilePath = action.SourceURL;
                 }
+                else if (this.ShowSaveSourceScreenshotGrid)
+                {
+                    this.ImageFormat = action.ImageFormat;
+                    this.ImageFilePath = action.ImageFilePath;
+                    this.ImageWidth = action.ImageWidth;
+                    this.ImageHeight = action.ImageHeight;
+                }
                 else if (this.ShowSourceDimensionsGrid)
                 {
                     this.SourceXPosition = action.SourceDimensions.X;
@@ -467,6 +537,17 @@ namespace MixItUp.Base.ViewModel.Actions
                         return Task.FromResult(new Result(MixItUp.Base.Resources.StreamingSoftwareActionMissingWebBrowserSourceFilePath));
                     }
                 }
+                else if (this.ShowSaveSourceScreenshotGrid)
+                {
+                    if (string.IsNullOrEmpty(this.ImageFormat))
+                    {
+                        return Task.FromResult(new Result(MixItUp.Base.Resources.StreamingSoftwareActionMissingImageFormat));
+                    }
+                    if (string.IsNullOrEmpty(this.ImageFilePath))
+                    {
+                        return Task.FromResult(new Result(MixItUp.Base.Resources.StreamingSoftwareActionMissingScreenshotFilePath));
+                    }
+                }
                 else if (this.ShowSourceDimensionsGrid)
                 {
 
@@ -514,6 +595,10 @@ namespace MixItUp.Base.ViewModel.Actions
                 else if (this.ShowWebBrowserSourceGrid)
                 {
                     return Task.FromResult<ActionModelBase>(StreamingSoftwareActionModel.CreateWebBrowserSourceAction(this.SelectedStreamingSoftwareType, this.SceneName, this.SourceName, this.SourceVisible, this.SourceWebPageFilePath));
+                }
+                else if (this.ShowSaveSourceScreenshotGrid)
+                {
+                    return Task.FromResult<ActionModelBase>(StreamingSoftwareActionModel.CreateSaveSourceScreenshotAction(this.SelectedStreamingSoftwareType, this.SourceName, this.ImageFormat, this.ImageFilePath, this.ImageWidth, this.ImageHeight));
                 }
                 else if (this.ShowSourceDimensionsGrid)
                 {

--- a/MixItUp.Base/ViewModel/MainControls/QuotesMainControlViewModel.cs
+++ b/MixItUp.Base/ViewModel/MainControls/QuotesMainControlViewModel.cs
@@ -63,6 +63,8 @@ namespace MixItUp.Base.ViewModel.MainControls
 
         public ICommand RenumberQuotesCommand { get; set; }
 
+        public ICommand DeleteAllQuotesCommand { get; set; }
+
         public QuotesMainControlViewModel(MainWindowViewModel windowViewModel)
             : base(windowViewModel)
         {
@@ -128,6 +130,22 @@ namespace MixItUp.Base.ViewModel.MainControls
                         sortedQuotes[i].ID = i + 1;
                     }
 
+                    await ChannelSession.Settings.SaveRenumberedQuotes();
+
+                    this.Refresh();
+                }
+            });
+
+            this.DeleteAllQuotesCommand = this.CreateCommand(async () =>
+            {
+                if (ChannelSession.Settings.Quotes.Count == 0)
+                {
+                    return;
+                }
+
+                if (await DialogHelper.ShowConfirmation(Resources.DeleteAllQuotesWarning))
+                {
+                    await ChannelSession.Settings.DeleteAllQuotes();
                     this.Refresh();
                 }
             });

--- a/MixItUp.Base/Web/AdvancedClientWebSocket.cs
+++ b/MixItUp.Base/Web/AdvancedClientWebSocket.cs
@@ -98,15 +98,22 @@ namespace MixItUp.Base.Web
                 this.LastConnectHttpStatusCode = this.ExtractHttpStatusCode(ex);
 
                 await this.DisconnectInternal(WebSocketCloseStatus.NormalClosure, waitForReceiveTask: true);
-                if (ex is WebSocketException && ex.InnerException is WebException)
+                if (ex is WebSocketException websocketEx)
                 {
-                    WebException webException = (WebException)ex.InnerException;
-                    if (webException.Response != null && webException.Response is HttpWebResponse)
+                    if (websocketEx.InnerException is WebException webException &&
+                        webException.Response is HttpWebResponse httpWebResponse)
                     {
-                        HttpWebResponse response = (HttpWebResponse)webException.Response;
-                        StreamReader reader = new StreamReader(response.GetResponseStream());
-                        string responseString = reader.ReadToEnd();
-                        throw new WebSocketException(string.Format("{0} - {1} - {2}", response.StatusCode, response.StatusDescription, responseString), ex);
+                        using (StreamReader reader = new StreamReader(httpWebResponse.GetResponseStream()))
+                        {
+                            string responseString = reader.ReadToEnd();
+                            throw new WebSocketException(string.Format("{0} - {1} - {2}", httpWebResponse.StatusCode, httpWebResponse.StatusDescription, responseString), ex);
+                        }
+                    }
+
+                    if (websocketEx.InnerException is HttpRequestException httpRequestEx &&
+                        httpRequestEx.StatusCode != null)
+                    {
+                        throw new WebSocketException(string.Format("{0} - {1}", (int)httpRequestEx.StatusCode.Value, httpRequestEx.Message), ex);
                     }
                 }
                 throw;

--- a/MixItUp.Base/Web/ClientWebSocketBase.cs
+++ b/MixItUp.Base/Web/ClientWebSocketBase.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Net;
+using System.Net.Http;
 using System.Net.WebSockets;
 using System.Threading;
 using System.Threading.Tasks;
@@ -40,15 +41,22 @@ namespace MixItUp.Base.Web
             catch (Exception ex)
             {
                 await this.Disconnect();
-                if (ex is WebSocketException && ex.InnerException is WebException)
+                if (ex is WebSocketException websocketEx)
                 {
-                    WebException webException = (WebException)ex.InnerException;
-                    if (webException.Response != null && webException.Response is HttpWebResponse)
+                    if (websocketEx.InnerException is WebException webException &&
+                        webException.Response is HttpWebResponse httpWebResponse)
                     {
-                        HttpWebResponse response = (HttpWebResponse)webException.Response;
-                        StreamReader reader = new StreamReader(response.GetResponseStream());
-                        string responseString = reader.ReadToEnd();
-                        throw new WebSocketException(string.Format("{0} - {1} - {2}", response.StatusCode, response.StatusDescription, responseString), ex);
+                        using (StreamReader reader = new StreamReader(httpWebResponse.GetResponseStream()))
+                        {
+                            string responseString = reader.ReadToEnd();
+                            throw new WebSocketException(string.Format("{0} - {1} - {2}", httpWebResponse.StatusCode, httpWebResponse.StatusDescription, responseString), ex);
+                        }
+                    }
+
+                    if (websocketEx.InnerException is HttpRequestException httpRequestEx &&
+                        httpRequestEx.StatusCode != null)
+                    {
+                        throw new WebSocketException(string.Format("{0} - {1}", (int)httpRequestEx.StatusCode.Value, httpRequestEx.Message), ex);
                     }
                 }
                 throw;

--- a/MixItUp.Base/Web/WebSocketBase.cs
+++ b/MixItUp.Base/Web/WebSocketBase.cs
@@ -73,10 +73,14 @@ namespace MixItUp.Base.Web
             byte[] buffer = Encoding.UTF8.GetBytes(packet);
 
             await this.webSocketSemaphore.WaitAsync();
-
-            await this.SendInternal(buffer);
-
-            this.webSocketSemaphore.Release();
+            try
+            {
+                await this.SendInternal(buffer);
+            }
+            finally
+            {
+                this.webSocketSemaphore.Release();
+            }
 
             this.OnSentOccurred?.Invoke(this, packet);
         }

--- a/MixItUp.Reporter/Properties/AssemblyInfo.cs
+++ b/MixItUp.Reporter/Properties/AssemblyInfo.cs
@@ -53,5 +53,5 @@ using System.Windows;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.6.311.0")]
-[assembly: AssemblyFileVersion("1.6.311.0")]
+[assembly: AssemblyVersion("1.6.312.0")]
+[assembly: AssemblyFileVersion("1.6.312.0")]

--- a/MixItUp.SignalR.Client/MixItUp.SignalR.Client.csproj
+++ b/MixItUp.SignalR.Client/MixItUp.SignalR.Client.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
 	  <AssemblyTitle>MixItUp.SignalR.Client</AssemblyTitle>
-    <AssemblyVersion>1.6.311.0</AssemblyVersion>
-    <FileVersion>1.6.311.0</FileVersion>
+    <AssemblyVersion>1.6.312.0</AssemblyVersion>
+    <FileVersion>1.6.312.0</FileVersion>
 	  <Company>Blazing Cacti LLC</Company>
 	  <Copyright>Copyright © 2026 Blazing Cacti LLC, All Rights Reserved. </Copyright>
   </PropertyGroup>

--- a/MixItUp.Uninstaller/Properties/AssemblyInfo.cs
+++ b/MixItUp.Uninstaller/Properties/AssemblyInfo.cs
@@ -37,5 +37,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.6.311.0")]
-[assembly: AssemblyFileVersion("1.6.311.0")]
+[assembly: AssemblyVersion("1.6.312.0")]
+[assembly: AssemblyFileVersion("1.6.312.0")]

--- a/MixItUp.WPF/Controls/Actions/StreamingSoftwareActionEditorControl.xaml
+++ b/MixItUp.WPF/Controls/Actions/StreamingSoftwareActionEditorControl.xaml
@@ -83,8 +83,8 @@
 
                 <TextBox Grid.Column="2" Text="{Binding SourceName}" MaterialDesign:HintAssist.Hint="{x:Static resx:Resources.SourceName}" Style="{StaticResource MaterialDesignFloatingHintTextBox}" />
 
-                <TextBlock Grid.Column="4" VerticalAlignment="Center" Text="{Binding Source={x:Static resx:Resources.Visible}, StringFormat={x:Static resx:Resources.ColumnHeaderFormat}}" />
-                <ToggleButton Grid.Column="6" IsChecked="{Binding SourceVisible}" VerticalAlignment="Center"/>
+                <TextBlock Grid.Column="4" Visibility="{Binding ShowSourceVisibilityToggle, Converter={StaticResource BooleanToVisibilityConverter}}" VerticalAlignment="Center" Text="{Binding Source={x:Static resx:Resources.Visible}, StringFormat={x:Static resx:Resources.ColumnHeaderFormat}}" />
+                <ToggleButton Grid.Column="6" Visibility="{Binding ShowSourceVisibilityToggle, Converter={StaticResource BooleanToVisibilityConverter}}" IsChecked="{Binding SourceVisible}" VerticalAlignment="Center"/>
             </Grid>
 
             <Grid Grid.Row="2" Visibility="{Binding ShowTextSourceGrid, Converter={StaticResource BooleanToVisibilityConverter}}">
@@ -143,6 +143,40 @@
                 <TextBox Grid.Column="0" Text="{Binding SourceWebPageFilePath}" Style="{StaticResource MaterialDesignFloatingHintTextBox}" MaterialDesign:HintAssist.Hint="{x:Static resx:Resources.WebPageOrLocalFile}" />
 
                 <Button Grid.Column="2" x:Name="SourceWebPageBrowseButton" Click="SourceWebPageBrowseButton_Click" Content="{x:Static resx:Resources.Browse}"/>
+            </Grid>
+
+            <Grid Grid.Row="2" Visibility="{Binding ShowSaveSourceScreenshotGrid, Converter={StaticResource BooleanToVisibilityConverter}}">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="10" />
+                    <RowDefinition Height="Auto" />
+                </Grid.RowDefinitions>
+
+                <Grid Grid.Row="0">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="20" />
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="20" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+
+                    <TextBox Grid.Column="0" Text="{Binding ImageFormat}" Width="90" MaterialDesign:HintAssist.Hint="{x:Static resx:Resources.ImageFormat}" Style="{StaticResource MaterialDesignFloatingHintTextBox}" />
+                    <TextBox Grid.Column="2" Text="{Binding ImageWidth}" MaterialDesign:HintAssist.Hint="{x:Static resx:Resources.ImageWidthOptional}" Style="{StaticResource MaterialDesignFloatingHintTextBox}" />
+                    <TextBox Grid.Column="4" Text="{Binding ImageHeight}" MaterialDesign:HintAssist.Hint="{x:Static resx:Resources.ImageHeightOptional}" Style="{StaticResource MaterialDesignFloatingHintTextBox}" />
+                </Grid>
+
+                <Grid Grid.Row="2">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="20" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+
+                    <TextBox Grid.Column="0" Text="{Binding ImageFilePath}" Style="{StaticResource MaterialDesignFloatingHintTextBox}" MaterialDesign:HintAssist.Hint="{x:Static resx:Resources.ImageFilePath}" />
+
+                    <Button Grid.Column="2" x:Name="SaveSourceScreenshotBrowseButton" Click="SaveSourceScreenshotBrowseButton_Click" Content="{x:Static resx:Resources.Browse}"/>
+                </Grid>
             </Grid>
 
             <Grid Grid.Row="2" Visibility="{Binding ShowSourceDimensionsGrid, Converter={StaticResource BooleanToVisibilityConverter}}">

--- a/MixItUp.WPF/Controls/Actions/StreamingSoftwareActionEditorControl.xaml.cs
+++ b/MixItUp.WPF/Controls/Actions/StreamingSoftwareActionEditorControl.xaml.cs
@@ -60,5 +60,17 @@ namespace MixItUp.WPF.Controls.Actions
                 }
             }
         }
+
+        private void SaveSourceScreenshotBrowseButton_Click(object sender, System.Windows.RoutedEventArgs e)
+        {
+            if (this.DataContext is StreamingSoftwareActionEditorControlViewModel)
+            {
+                string filePath = ServiceManager.Get<IFileService>().ShowSaveFileDialog(((StreamingSoftwareActionEditorControlViewModel)this.DataContext).ImageFilePath, MixItUp.Base.Resources.ImageFileFormatFilter);
+                if (!string.IsNullOrEmpty(filePath))
+                {
+                    ((StreamingSoftwareActionEditorControlViewModel)this.DataContext).ImageFilePath = filePath;
+                }
+            }
+        }
     }
 }

--- a/MixItUp.WPF/Controls/MainControls/ChangelogControl.xaml.cs
+++ b/MixItUp.WPF/Controls/MainControls/ChangelogControl.xaml.cs
@@ -1,9 +1,7 @@
-﻿using MixItUp.Base.Model.API;
-using MixItUp.Base.Services;
-using MixItUp.Base.Util;
+﻿using MixItUp.Base.Util;
 using System;
 using System.Diagnostics;
-using System.Net.Http;
+using System.IO;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Documents;
@@ -28,26 +26,14 @@ namespace MixItUp.WPF.Controls.MainControls
         {
             try
             {
-                MixItUpUpdateModel update = await ServiceManager.Get<MixItUpService>().GetLatestUpdate();
-                if (update != null)
+                string changelogFilePath = Path.Combine(AppContext.BaseDirectory, "CHANGELOG.md");
+                if (File.Exists(changelogFilePath))
                 {
-                    using (HttpClient client = new HttpClient())
-                    {
-                        HttpResponseMessage response = await client.GetAsync(update.ChangelogLink);
-                        if (response.IsSuccessStatusCode)
-                        {
-                            string markdown = await response.Content.ReadAsStringAsync();
-                            this.ChangelogViewer.Markdown = markdown;
-                        }
-                        else
-                        {
-                            Logger.Log(LogLevel.Warning, $"Failed to retrieve changelog from {update.ChangelogLink}: {(int)response.StatusCode} {response.ReasonPhrase}");
-                            this.ChangelogViewer.Markdown = "Unable to load changelog.";
-                        }
-                    }
+                    this.ChangelogViewer.Markdown = await File.ReadAllTextAsync(changelogFilePath);
                 }
                 else
                 {
+                    Logger.Log(LogLevel.Warning, $"Bundled changelog not found at {changelogFilePath}");
                     this.ChangelogViewer.Markdown = "No changelog available.";
                 }
             }

--- a/MixItUp.WPF/Controls/MainControls/QuoteControl.xaml
+++ b/MixItUp.WPF/Controls/MainControls/QuoteControl.xaml
@@ -65,6 +65,13 @@
                             <TextBlock VerticalAlignment="Center" Foreground="{DynamicResource MaterialDesign.Brush.Foreground}" Text="{x:Static resx:Resources.RenumberQuotes}" />
                         </StackPanel>
                     </Button>
+                    <Separator Margin="0,2" />
+                    <Button HorizontalContentAlignment="Left" Command="{Binding DeleteAllQuotesCommand}" Style="{StaticResource MaterialDesignFlatButton}">
+                        <StackPanel Orientation="Horizontal">
+                            <MaterialDesign:PackIcon Width="18" Height="18" Margin="0,0,8,0" VerticalAlignment="Center" Foreground="{DynamicResource MaterialDesign.Brush.Primary}" Kind="DeleteForever" />
+                            <TextBlock VerticalAlignment="Center" Foreground="{DynamicResource MaterialDesign.Brush.Foreground}" Text="{x:Static resx:Resources.DeleteAllQuotes}" />
+                        </StackPanel>
+                    </Button>
                 </StackPanel>
             </MaterialDesign:PopupBox>
         </Grid>

--- a/MixItUp.WPF/LoginWindow.xaml.cs
+++ b/MixItUp.WPF/LoginWindow.xaml.cs
@@ -190,15 +190,6 @@ namespace MixItUp.WPF
                 {
                     updateFound = true;
 
-                    if (this.currentUpdate.Mandatory)
-                    {
-                        bool launched = await UpdateWindow.DownloadAndInstallUpdate(this.currentUpdate);
-                        if (launched)
-                        {
-                            return;
-                        }
-                    }
-
                     UpdateWindow window = new UpdateWindow(this.currentUpdate);
                     window.Show();
                 }

--- a/MixItUp.WPF/MixItUp.WPF.csproj
+++ b/MixItUp.WPF/MixItUp.WPF.csproj
@@ -9,8 +9,8 @@
     <AssemblyTitle>MixItUp.Client</AssemblyTitle>
     <Company>Blazing Cacti LLC</Company>
 		<Copyright>Copyright © 2026 Blazing Cacti LLC, All Rights Reserved.</Copyright>
-    <AssemblyVersion>1.6.311.0</AssemblyVersion>
-    <FileVersion>1.6.311.0</FileVersion>
+    <AssemblyVersion>1.6.312.0</AssemblyVersion>
+    <FileVersion>1.6.312.0</FileVersion>
 		<Version>1.6.0</Version>
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <PublishUrl>publish\</PublishUrl>

--- a/MixItUp.WPF/MixItUp.WPF.csproj
+++ b/MixItUp.WPF/MixItUp.WPF.csproj
@@ -77,7 +77,6 @@ del $(TargetDir)MixItUp.zip</PostBuildEvent>
 		<PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.135" />
 		<PackageReference Include="NAudio" Version="2.2.1" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-		<PackageReference Include="obs-websocket-dotnet" Version="5.0.1" />
 		<PackageReference Include="ovrstream-client-csharp" Version="0.0.2" />
 		<PackageReference Include="PixiEditor.ColorPicker" Version="3.4.2.2" />
 		<PackageReference Include="SixLabors.ImageSharp" Version="2.1.12" />

--- a/MixItUp.WPF/Properties/AssemblyInfo.cs
+++ b/MixItUp.WPF/Properties/AssemblyInfo.cs
@@ -50,5 +50,5 @@ using System.Windows;
 //
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("1.6.311.0")]
-[assembly: AssemblyFileVersion("1.6.311.0")]
+[assembly: AssemblyVersion("1.6.312.0")]
+[assembly: AssemblyFileVersion("1.6.312.0")]

--- a/MixItUp.WPF/Services/WindowsOBSService.cs
+++ b/MixItUp.WPF/Services/WindowsOBSService.cs
@@ -3,13 +3,15 @@ using MixItUp.Base.Model.Actions;
 using MixItUp.Base.Services;
 using MixItUp.Base.Services.External;
 using MixItUp.Base.Util;
+using MixItUp.Base.Web;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using OBSWebsocketDotNet;
-using OBSWebsocketDotNet.Communication;
-using OBSWebsocketDotNet.Types;
 using System;
-using System.Collections.Generic;
+using System.Collections.Concurrent;
+using System.Linq;
 using System.Net.WebSockets;
+using System.Security.Cryptography;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -23,7 +25,7 @@ namespace MixItUp.WPF.Services
         public event EventHandler Connected = delegate { };
         public event EventHandler Disconnected = delegate { };
 
-        private readonly OBSWebsocket OBSWebsocket = new OBSWebsocket();
+        private readonly OBSWebsocketV5 OBSWebsocketV5 = new OBSWebsocketV5();
         private readonly SemaphoreSlim operationSemaphore = new SemaphoreSlim(1, 1);
 
         private int reconnectLoopRunning = 0;
@@ -33,8 +35,7 @@ namespace MixItUp.WPF.Services
 
         public WindowsOBSService()
         {
-            this.OBSWebsocket.WSTimeout = TimeSpan.FromMilliseconds(ConnectTimeoutInMilliseconds);
-            this.OBSWebsocket.Disconnected += this.OBSWebsocket_Disconnected;
+            this.OBSWebsocketV5.Disconnected += this.OBSWebsocketV5_Disconnected;
         }
 
         public string Name { get { return "OBS Studio"; } }
@@ -60,16 +61,19 @@ namespace MixItUp.WPF.Services
         public async Task ShowScene(string sceneName)
         {
             Logger.Log(LogLevel.Debug, "Showing OBS Scene - " + sceneName);
-            await this.ExecuteOBSCommand(() =>
+            await this.ExecuteOBSCommand(async () =>
             {
-                this.OBSWebsocket.SetCurrentProgramScene(sceneName);
+                await this.OBSWebsocketV5.SetCurrentScene(sceneName);
                 return true;
             });
         }
 
         public async Task<string> GetCurrentScene()
         {
-            string sceneName = await this.ExecuteOBSCommand(() => this.OBSWebsocket.GetCurrentProgramScene(), defaultValue: "Unknown");
+            string sceneName = await this.ExecuteOBSCommand(async () =>
+            {
+                return await this.OBSWebsocketV5.GetCurrentSceneName();
+            }, defaultValue: "Unknown");
             Logger.Log(LogLevel.Debug, "Current OBS Scene - " + sceneName);
             return sceneName;
         }
@@ -77,12 +81,13 @@ namespace MixItUp.WPF.Services
         public async Task SetSourceVisibility(string sceneName, string sourceName, bool visibility)
         {
             Logger.Log(LogLevel.Debug, "Setting source visibility - " + sourceName);
-            await this.ExecuteOBSCommand(() =>
+            await this.ExecuteOBSCommand(async () =>
             {
-                if (this.TryGetSceneItemReference(this.ResolveSceneName(sceneName), sourceName, out string targetSceneName, out int sceneItemId))
+                if (string.IsNullOrEmpty(sceneName))
                 {
-                    this.OBSWebsocket.SetSceneItemEnabled(targetSceneName, sceneItemId, visibility);
+                    sceneName = await this.OBSWebsocketV5.GetCurrentSceneName();
                 }
+                await this.OBSWebsocketV5.SetSourceRender(sourceName, visibility, sceneName);
                 return true;
             });
         }
@@ -90,9 +95,9 @@ namespace MixItUp.WPF.Services
         public async Task SetSourceFilterVisibility(string sourceName, string filterName, bool visibility)
         {
             Logger.Log(LogLevel.Debug, "Setting source filter visibility - " + sourceName + " - " + filterName);
-            await this.ExecuteOBSCommand(() =>
+            await this.ExecuteOBSCommand(async () =>
             {
-                this.OBSWebsocket.SetSourceFilterEnabled(sourceName, filterName, visibility);
+                await this.OBSWebsocketV5.SetSourceFilterVisibility(sourceName, filterName, visibility);
                 return true;
             });
         }
@@ -100,13 +105,13 @@ namespace MixItUp.WPF.Services
         public async Task SetImageSourceFilePath(string sceneName, string sourceName, string filePath)
         {
             Logger.Log(LogLevel.Debug, "Setting image source file path - " + sourceName);
-            await this.ExecuteOBSCommand(() =>
+            await this.ExecuteOBSCommand(async () =>
             {
-                InputSettings inputSettings = this.OBSWebsocket.GetInputSettings(sourceName);
-                if (inputSettings?.Settings != null)
+                JObject settings = await this.OBSWebsocketV5.GetSourceSettings(sourceName);
+                if (settings != null)
                 {
-                    inputSettings.Settings["file"] = filePath;
-                    this.OBSWebsocket.SetInputSettings(sourceName, inputSettings.Settings, overlay: true);
+                    settings["file"] = filePath;
+                    await this.OBSWebsocketV5.SetSourceSettings(sourceName, settings);
                 }
                 return true;
             });
@@ -115,13 +120,13 @@ namespace MixItUp.WPF.Services
         public async Task SetMediaSourceFilePath(string sceneName, string sourceName, string filePath)
         {
             Logger.Log(LogLevel.Debug, "Setting media source file path - " + sourceName);
-            await this.ExecuteOBSCommand(() =>
+            await this.ExecuteOBSCommand(async () =>
             {
-                InputSettings inputSettings = this.OBSWebsocket.GetInputSettings(sourceName);
-                if (inputSettings?.Settings != null)
+                JObject settings = await this.OBSWebsocketV5.GetSourceSettings(sourceName);
+                if (settings != null)
                 {
-                    inputSettings.Settings["local_file"] = filePath;
-                    this.OBSWebsocket.SetInputSettings(sourceName, inputSettings.Settings, overlay: true);
+                    settings["local_file"] = filePath;
+                    await this.OBSWebsocketV5.SetSourceSettings(sourceName, settings);
                 }
                 return true;
             });
@@ -133,13 +138,10 @@ namespace MixItUp.WPF.Services
 
             await this.SetSourceVisibility(sceneName, sourceName, visibility: false);
 
-            await this.ExecuteOBSCommand(() =>
+            await this.ExecuteOBSCommand(async () =>
             {
-                InputSettings inputSettings = this.OBSWebsocket.GetInputSettings(sourceName);
-                JObject settings = inputSettings?.Settings ?? new JObject();
-                settings["is_local_file"] = false;
-                settings["url"] = url;
-                this.OBSWebsocket.SetInputSettings(sourceName, settings, overlay: true);
+                JObject settings = new JObject { ["url"] = url };
+                await this.OBSWebsocketV5.SetSourceSettings(sourceName, settings);
                 return true;
             });
         }
@@ -147,107 +149,82 @@ namespace MixItUp.WPF.Services
         public async Task SetSourceDimensions(string sceneName, string sourceName, StreamingSoftwareSourceDimensionsModel dimensions)
         {
             Logger.Log(LogLevel.Debug, "Setting source dimensions - " + sourceName);
-            await this.ExecuteOBSCommand(() =>
+            await this.ExecuteOBSCommand(async () =>
             {
-                if (this.TryGetSceneItemReference(this.ResolveSceneName(sceneName), sourceName, out string targetSceneName, out int sceneItemId))
+                if (string.IsNullOrEmpty(sceneName))
                 {
-                    JObject transform = new JObject
-                    {
-                        ["positionX"] = dimensions.X,
-                        ["positionY"] = dimensions.Y,
-                        ["scaleX"] = dimensions.XScale,
-                        ["scaleY"] = dimensions.YScale,
-                        ["rotation"] = dimensions.Rotation,
-                    };
-
-                    this.OBSWebsocket.SetSceneItemTransform(targetSceneName, sceneItemId, transform);
+                    sceneName = await this.OBSWebsocketV5.GetCurrentSceneName();
                 }
+                await this.OBSWebsocketV5.SetSceneItemProperties(sceneName, sourceName, dimensions.X, dimensions.Y, dimensions.XScale, dimensions.YScale, dimensions.Rotation);
                 return true;
             });
         }
 
         public async Task<StreamingSoftwareSourceDimensionsModel> GetSourceDimensions(string sceneName, string sourceName)
         {
-            return await this.ExecuteOBSCommand(() =>
+            return await this.ExecuteOBSCommand(async () =>
             {
-                if (this.TryGetSceneItemReference(this.ResolveSceneName(sceneName), sourceName, out string targetSceneName, out int sceneItemId))
+                if (string.IsNullOrEmpty(sceneName))
                 {
-                    SceneItemTransformInfo transform = this.OBSWebsocket.GetSceneItemTransform(targetSceneName, sceneItemId);
-                    return new StreamingSoftwareSourceDimensionsModel()
-                    {
-                        X = (int)transform.X,
-                        Y = (int)transform.Y,
-                        Rotation = (int)transform.Rotation,
-                        XScale = (float)transform.ScaleX,
-                        YScale = (float)transform.ScaleY,
-                    };
+                    sceneName = await this.OBSWebsocketV5.GetCurrentSceneName();
                 }
 
+                var response = await this.OBSWebsocketV5.GetSceneItemTransform(sceneName, sourceName);
+                if (response.HasValue)
+                {
+                    return new StreamingSoftwareSourceDimensionsModel()
+                    {
+                        X = (int)response.Value.X,
+                        Y = (int)response.Value.Y,
+                        XScale = (response.Value.Width / response.Value.SourceWidth),
+                        YScale = (response.Value.Height / response.Value.SourceHeight),
+                    };
+                }
                 return null;
             });
         }
 
         public async Task StartStopStream()
         {
-            await this.ExecuteOBSCommand(() =>
+            await this.ExecuteOBSCommand(async () =>
             {
-                this.OBSWebsocket.ToggleStream();
+                await this.OBSWebsocketV5.StartStopStreaming();
                 return true;
             });
         }
 
         public async Task StartStopRecording()
         {
-            await this.ExecuteOBSCommand(() =>
+            await this.ExecuteOBSCommand(async () =>
             {
-                this.OBSWebsocket.ToggleRecord();
+                await this.OBSWebsocketV5.StartStopRecording();
                 return true;
             });
         }
 
         public async Task<bool> StartReplayBuffer()
         {
-            return await this.ExecuteOBSCommand(() =>
+            return await this.ExecuteOBSCommand(async () =>
             {
-                try
-                {
-                    if (this.OBSWebsocket.GetReplayBufferStatus())
-                    {
-                        return true;
-                    }
-
-                    this.OBSWebsocket.StartReplayBuffer();
-                    return true;
-                }
-                catch (ErrorResponseException ex)
-                {
-                    if (ex.ErrorCode == 604)
-                    {
-                        return true;
-                    }
-                    if (ex.ErrorCode == 500 && this.OBSWebsocket.GetReplayBufferStatus())
-                    {
-                        return true;
-                    }
-                    throw;
-                }
+                await this.OBSWebsocketV5.StartReplayBuffer();
+                return true;
             }, defaultValue: false);
         }
 
         public async Task SaveReplayBuffer()
         {
-            await this.ExecuteOBSCommand(() =>
+            await this.ExecuteOBSCommand(async () =>
             {
-                this.OBSWebsocket.SaveReplayBuffer();
+                await this.OBSWebsocketV5.SaveReplayBuffer();
                 return true;
             });
         }
 
         public async Task SetSceneCollection(string sceneCollectionName)
         {
-            await this.ExecuteOBSCommand(() =>
+            await this.ExecuteOBSCommand(async () =>
             {
-                this.OBSWebsocket.SetCurrentSceneCollection(sceneCollectionName);
+                await this.OBSWebsocketV5.SetCurrentSceneCollection(sceneCollectionName);
                 return true;
             });
         }
@@ -261,17 +238,9 @@ namespace MixItUp.WPF.Services
             await this.operationSemaphore.WaitAsync();
             try
             {
-                if (!this.OBSWebsocket.IsConnected)
+                if (!this.OBSWebsocketV5.IsConnected)
                 {
-                    try
-                    {
-                        this.OBSWebsocket.ConnectAsync(ChannelSession.Settings.OBSStudioServerIP, ChannelSession.Settings.OBSStudioServerPassword);
-                        attemptedConnect = true;
-                    }
-                    catch (Exception ex)
-                    {
-                        this.LogConnectFailure(ex);
-                    }
+                    attemptedConnect = true;
                 }
             }
             finally
@@ -283,18 +252,29 @@ namespace MixItUp.WPF.Services
             {
                 try
                 {
-                    await this.WaitForConnectedState(TimeSpan.FromMilliseconds(ConnectTimeoutInMilliseconds));
+                    using (CancellationTokenSource cts = new CancellationTokenSource(ConnectTimeoutInMilliseconds))
+                    {
+                        string connectError = await this.OBSWebsocketV5.Connect(
+                            ChannelSession.Settings.OBSStudioServerIP,
+                            ChannelSession.Settings.OBSStudioServerPassword,
+                            cts.Token);
+
+                        if (connectError != null)
+                        {
+                            Logger.Log(LogLevel.Warning, "OBS Studio connection failed: " + connectError);
+                        }
+                    }
                 }
                 catch (Exception ex)
                 {
-                    this.LogConnectFailure(ex);
+                    Logger.Log(LogLevel.Warning, "OBS Studio connection failed: " + ex.Message);
                 }
             }
 
             await this.operationSemaphore.WaitAsync();
             try
             {
-                this.IsConnected = this.OBSWebsocket.IsConnected;
+                this.IsConnected = this.OBSWebsocketV5.IsConnected;
                 if (this.IsConnected)
                 {
                     if (attemptedConnect)
@@ -330,16 +310,15 @@ namespace MixItUp.WPF.Services
 
         private async Task DisconnectInternal(bool notifyDisconnected)
         {
-            bool wasConnected = this.IsConnected || this.OBSWebsocket.IsConnected;
+            bool wasConnected = this.IsConnected || this.OBSWebsocketV5.IsConnected;
 
             await this.operationSemaphore.WaitAsync();
             try
             {
                 this.IsConnected = false;
-
-                if (this.OBSWebsocket.IsConnected)
+                if (this.OBSWebsocketV5.IsConnected)
                 {
-                    this.OBSWebsocket.Disconnect();
+                    await this.OBSWebsocketV5.Disconnect();
                 }
             }
             catch (Exception ex)
@@ -357,7 +336,7 @@ namespace MixItUp.WPF.Services
             }
         }
 
-        private void OBSWebsocket_Disconnected(object sender, ObsDisconnectionInfo e)
+        private void OBSWebsocketV5_Disconnected(object sender, EventArgs e)
         {
             bool wasConnected = this.IsConnected;
             this.IsConnected = false;
@@ -366,13 +345,6 @@ namespace MixItUp.WPF.Services
             {
                 return;
             }
-
-            string disconnectDetails = $"OBS disconnect - Code: {e?.ObsCloseCode}, Reason: {e?.DisconnectReason}";
-            if (e?.WebsocketDisconnectionInfo?.Exception != null)
-            {
-                disconnectDetails += $", Exception: {e.WebsocketDisconnectionInfo.Exception.Message}";
-            }
-            Logger.Log(LogLevel.Warning, disconnectDetails);
 
             if (!wasConnected)
             {
@@ -406,12 +378,8 @@ namespace MixItUp.WPF.Services
                         }
                     }
                 }
-                catch (TaskCanceledException)
-                {
-                }
-                catch (OperationCanceledException)
-                {
-                }
+                catch (TaskCanceledException) { }
+                catch (OperationCanceledException) { }
                 catch (Exception ex)
                 {
                     Logger.Log(ex);
@@ -437,9 +405,9 @@ namespace MixItUp.WPF.Services
             ChannelSession.DisconnectionOccurred(MixItUp.Base.Resources.OBSStudio);
         }
 
-        private async Task<T> ExecuteOBSCommand<T>(Func<T> command, int timeout = CommandTimeoutInMilliseconds, T defaultValue = default)
+        private async Task<T> ExecuteOBSCommand<T>(Func<Task<T>> command, int timeout = CommandTimeoutInMilliseconds, T defaultValue = default)
         {
-            if (!this.IsConnected || !this.OBSWebsocket.IsConnected)
+            if (!this.IsConnected || !this.OBSWebsocketV5.IsConnected)
             {
                 this.IsConnected = false;
                 return defaultValue;
@@ -448,13 +416,13 @@ namespace MixItUp.WPF.Services
             await this.operationSemaphore.WaitAsync();
             try
             {
-                if (!this.OBSWebsocket.IsConnected)
+                if (!this.OBSWebsocketV5.IsConnected)
                 {
                     this.IsConnected = false;
                     return defaultValue;
                 }
 
-                return await Task.Run(command).WaitAsync(TimeSpan.FromMilliseconds(timeout));
+                return await command().WaitAsync(TimeSpan.FromMilliseconds(timeout));
             }
             catch (Exception ex)
             {
@@ -467,7 +435,7 @@ namespace MixItUp.WPF.Services
                     Logger.Log(ex);
                 }
 
-                if (this.IsConnectionException(ex))
+                if (ex is TimeoutException || ex is WebSocketException || ex is OperationCanceledException)
                 {
                     this.IsConnected = false;
                     if (Interlocked.CompareExchange(ref this.manualDisconnectRequested, 0, 0) == 0)
@@ -484,138 +452,921 @@ namespace MixItUp.WPF.Services
                 this.operationSemaphore.Release();
             }
         }
+    }
 
-        private string ResolveSceneName(string sceneName)
+    public class OBSWebsocketV5 : AdvancedClientWebSocket
+    {
+        private const string SceneNameChangedEvent = "SceneNameChanged";
+        private const string SceneItemRemovedEvent = "SceneItemRemoved";
+        private const string InputRemovedEvent = "InputRemoved";
+        private const string InputNameChangedEvent = "InputNameChanged";
+
+        private string password;
+        private bool identified = false;
+        private string identifyError = null;
+        private ConcurrentDictionary<Guid, TaskCompletionSource<string>> responses = new ConcurrentDictionary<Guid, TaskCompletionSource<string>>();
+        private SemaphoreSlim sendSemaphore = new SemaphoreSlim(1);
+        private ConcurrentDictionary<string, ConcurrentDictionary<string, SceneItem>> sceneSourceNameToSceneItemDictionary = new ConcurrentDictionary<string, ConcurrentDictionary<string, SceneItem>>(StringComparer.OrdinalIgnoreCase);
+
+        public new event EventHandler Disconnected;
+
+        public bool IsConnected => this.identified;
+
+        public OBSWebsocketV5()
         {
-            if (!string.IsNullOrEmpty(sceneName))
+            base.PacketReceived += async (sender, packet) => await ProcessReceivedPacket(packet);
+            base.Disconnected += (sender, closeStatus) =>
             {
-                return sceneName;
-            }
-            return this.OBSWebsocket.GetCurrentProgramScene();
+                bool wasIdentified = this.identified;
+                this.identified = false;
+                this.CancelAllRequests();
+
+                if ((int)closeStatus == 4009)
+                {
+                    this.identifyError = "Authentication failed - please check your OBS WebSocket password (code: 4009)";
+                }
+                else if (!wasIdentified)
+                {
+                    this.identifyError = $"Connection closed during handshake (code: {(int)closeStatus})";
+                }
+
+                this.Disconnected?.Invoke(this, EventArgs.Empty);
+            };
         }
 
-        private bool TryGetSceneItemReference(string sceneName, string sourceName, out string targetSceneName, out int sceneItemId)
+
+        public async Task<string> Connect(string endpoint, string password, CancellationToken cancellationToken)
         {
-            targetSceneName = sceneName;
-            sceneItemId = 0;
-
-            if (this.TryGetSceneItemId(sceneName, sourceName, out sceneItemId))
-            {
-                return true;
-            }
-
-            foreach (SceneItemDetails sceneItem in this.OBSWebsocket.GetSceneItemList(sceneName) ?? new List<SceneItemDetails>())
-            {
-                if (!string.Equals(sceneItem.SourceKind, "group", StringComparison.OrdinalIgnoreCase))
-                {
-                    continue;
-                }
-
-                if (this.TryGetSceneItemId(sceneItem.SourceName, sourceName, out sceneItemId))
-                {
-                    targetSceneName = sceneItem.SourceName;
-                    return true;
-                }
-            }
-
-            foreach (string groupName in this.OBSWebsocket.GetGroupList() ?? new List<string>())
-            {
-                if (this.TryGetSceneItemId(groupName, sourceName, out sceneItemId))
-                {
-                    targetSceneName = groupName;
-                    return true;
-                }
-            }
-
-            return false;
-        }
-
-        private bool TryGetSceneItemId(string sceneName, string sourceName, out int sceneItemId)
-        {
-            sceneItemId = 0;
+            this.password = password;
+            this.identified = false;
+            this.identifyError = null;
 
             try
             {
-                sceneItemId = this.OBSWebsocket.GetSceneItemId(sceneName, sourceName, 0);
-                return true;
+                await base.Connect(endpoint, cancellationToken);
             }
-            catch
+            catch (Exception ex)
             {
-                return false;
+                string detail = base.LastConnectHttpStatusCode.HasValue
+                    ? $"HTTP {base.LastConnectHttpStatusCode.Value} - {ex.Message}"
+                    : ex.Message;
+                return detail;
+            }
+
+            if (!base.IsOpen())
+            {
+                string detail = "WebSocket failed to open";
+                if (base.LastConnectHttpStatusCode.HasValue)
+                {
+                    detail += $" (HTTP {base.LastConnectHttpStatusCode.Value})";
+                }
+                return detail;
+            }
+
+            while (!this.identified && this.identifyError == null && !cancellationToken.IsCancellationRequested)
+            {
+                await Task.Delay(100, cancellationToken);
+            }
+
+            if (cancellationToken.IsCancellationRequested)
+            {
+                await base.Disconnect();
+                return "Connection timed out during OBS identification handshake";
+            }
+
+            if (this.identifyError != null)
+            {
+                await base.Disconnect();
+                return this.identifyError;
+            }
+
+            return null;
+        }
+
+        public new async Task Disconnect(WebSocketCloseStatus closeStatus = WebSocketCloseStatus.NormalClosure)
+        {
+            this.identified = false;
+            this.CancelAllRequests();
+            await base.Disconnect(closeStatus);
+        }
+
+        public async Task SetCurrentScene(string sceneName)
+        {
+            await Send(new OBSMessageSetCurrentProgramSceneRequest(sceneName));
+        }
+
+        public async Task SetCurrentSceneCollection(string sceneCollectionName)
+        {
+            await Send(new OBSMessageSetCurrentSceneCollectionRequest(sceneCollectionName));
+        }
+
+        public async Task SaveReplayBuffer()
+        {
+            await Send(new OBSMessageSaveReplayBufferRequest());
+        }
+
+        public async Task StartReplayBuffer()
+        {
+            string packet = await SendAndWait(new OBSMessageStartReplayBufferRequest());
+            if (!string.IsNullOrEmpty(packet))
+            {
+                OBSMessageResponse response = JSONSerializerHelper.DeserializeFromString<OBSMessageResponse>(packet);
+                if (response?.Data?.Status != null && !response.Data.Status.Result)
+                {
+                    if (response.Data.Status.Code == 500 || response.Data.Status.Code == 604)
+                    {
+                        return;
+                    }
+                    throw new Exception(response.Data.Status.Comment);
+                }
             }
         }
 
-        private void LogConnectFailure(Exception ex)
+        public async Task StartStopRecording()
         {
-            Exception current = this.GetInnermostException(ex);
+            await Send(new OBSMessageToggleRecordRequest());
+        }
 
-            if (this.IsConnectionException(ex))
+        public async Task StartStopStreaming()
+        {
+            await Send(new OBSMessageToggleStreamRequest());
+        }
+
+        public async Task<string> GetCurrentSceneName()
+        {
+            string packet = await SendAndWait(new OBSMessageGetCurrentProgramSceneRequest());
+            if (!string.IsNullOrEmpty(packet))
             {
-                Logger.Log(LogLevel.Warning, "OBS Studio connection failed: " + current.Message);
-                Logger.Log(LogLevel.Warning, ex, includeStackTrace: true);
+                OBSMessageGetCurrentProgramSceneResponse response = JSONSerializerHelper.DeserializeFromString<OBSMessageGetCurrentProgramSceneResponse>(packet);
+                return response?.Data?.Data?.CurrentProgramSceneName ?? "Unknown";
+            }
+            return "Unknown";
+        }
+
+        public async Task SetSceneItemProperties(string sceneName, string sourceName, int x, int y, float xScale, float yScale, float rotation)
+        {
+            SceneItem sceneItem = await this.SearchForSceneItem(sourceName, sceneName);
+            if (sceneItem != null)
+            {
+                JObject newTransform = new JObject
+                {
+                    ["positionX"] = x,
+                    ["positionY"] = y,
+                    ["scaleX"] = xScale,
+                    ["scaleY"] = yScale,
+                    ["rotation"] = rotation
+                };
+                string packet = await SendAndWait(new OBSMessageSetSceneItemTransformRequest(sceneItem.GroupName ?? sceneName, sceneItem.SceneItemId, newTransform));
+                if (!string.IsNullOrEmpty(packet))
+                {
+                    OBSMessageResponse response = JSONSerializerHelper.DeserializeFromString<OBSMessageResponse>(packet);
+                    if (response?.Data?.Status?.Code == 600)
+                    {
+                        if (sceneSourceNameToSceneItemDictionary.TryGetValue(sceneName, out var items))
+                        {
+                            items.TryRemove(sourceName, out _);
+                        }
+                        sceneItem = await this.SearchForSceneItem(sourceName, sceneName);
+                        if (sceneItem != null)
+                        {
+                            await Send(new OBSMessageSetSceneItemTransformRequest(sceneItem.GroupName ?? sceneName, sceneItem.SceneItemId, newTransform));
+                        }
+                    }
+                }
+            }
+        }
+
+        public async Task<JObject> GetSourceSettings(string sourceName)
+        {
+            string packet = await SendAndWait(new OBSMessageGetInputSettingsRequest(sourceName));
+            if (!string.IsNullOrEmpty(packet))
+            {
+                OBSMessageGetInputSettingsResponse response = JSONSerializerHelper.DeserializeFromString<OBSMessageGetInputSettingsResponse>(packet);
+                return response?.Data?.Data?.InputSettings;
+            }
+            return null;
+        }
+
+        public async Task SetSourceSettings(string sourceName, JObject settings)
+        {
+            await Send(new OBSMessageSetInputSettingsRequest(sourceName, settings));
+        }
+
+        public async Task SetSourceFilterVisibility(string sourceName, string filterName, bool visibility)
+        {
+            await Send(new OBSMessageSetSourceFilterEnabledRequest(sourceName, filterName, visibility));
+        }
+
+        public async Task SetSourceRender(string sourceName, bool visibility, string sceneName)
+        {
+            SceneItem sceneItem = await this.SearchForSceneItem(sourceName, sceneName);
+            if (sceneItem != null)
+            {
+                string packet = await SendAndWait(new OBSMessageSetSceneItemEnabledRequest(sceneItem.GroupName ?? sceneName, sceneItem.SceneItemId, visibility));
+                if (!string.IsNullOrEmpty(packet))
+                {
+                    OBSMessageResponse response = JSONSerializerHelper.DeserializeFromString<OBSMessageResponse>(packet);
+                    if (response?.Data?.Status?.Code == 600)
+                    {
+                        if (sceneSourceNameToSceneItemDictionary.TryGetValue(sceneName, out var items))
+                        {
+                            items.TryRemove(sourceName, out _);
+                        }
+                        sceneItem = await this.SearchForSceneItem(sourceName, sceneName);
+                        if (sceneItem != null)
+                        {
+                            await Send(new OBSMessageSetSceneItemEnabledRequest(sceneItem.GroupName ?? sceneName, sceneItem.SceneItemId, visibility));
+                        }
+                    }
+                }
+            }
+        }
+
+        public async Task<(float X, float Y, float Width, float Height, float SourceWidth, float SourceHeight)?> GetSceneItemTransform(string sceneName, string sourceName)
+        {
+            SceneItem item = await this.SearchForSceneItem(sourceName, sceneName);
+            if (item?.SceneItemTransform != null)
+            {
+                return (
+                    item.SceneItemTransform.PositionX,
+                    item.SceneItemTransform.PositionY,
+                    item.SceneItemTransform.Width,
+                    item.SceneItemTransform.Height,
+                    item.SceneItemTransform.SourceWidth,
+                    item.SceneItemTransform.SourceHeight
+                );
+            }
+            return null;
+        }
+
+        private async Task<SceneItem> SearchForSceneItem(string sourceName, string sceneName)
+        {
+            // Check our scene cache first
+            if (sceneSourceNameToSceneItemDictionary.TryGetValue(sceneName, out var sceneItems))
+            {
+                if (sceneItems.TryGetValue(sourceName, out var cachedItem))
+                {
+                    return cachedItem;
+                }
             }
             else
+            {
+                sceneSourceNameToSceneItemDictionary[sceneName] = new ConcurrentDictionary<string, SceneItem>(StringComparer.OrdinalIgnoreCase);
+            }
+
+            // Failed hit, invalid the scene's cache
+            sceneSourceNameToSceneItemDictionary[sceneName].Clear();
+
+            string packet = await SendAndWait(new OBSMessageGetSceneItemListRequest(sceneName));
+            if (!string.IsNullOrEmpty(packet))
+            {
+                OBSMessageGetSceneItemListResponse response = JSONSerializerHelper.DeserializeFromString<OBSMessageGetSceneItemListResponse>(packet);
+                if (response?.Data?.Data != null)
+                {
+                    // Cache all items first
+                    foreach (SceneItem sceneItem in response.Data.Data.SceneItems)
+                    {
+                        sceneSourceNameToSceneItemDictionary[sceneName][sceneItem.SourceName] = sceneItem;
+                    }
+
+                    foreach (SceneItem sceneItem in response.Data.Data.SceneItems)
+                    {
+                        if (string.Equals(sceneItem.SourceName, sourceName, StringComparison.OrdinalIgnoreCase))
+                        {
+                            return sceneItem;
+                        }
+                    }
+
+                    // If we got here, then the item is not found, search groups (this is slow)
+                    foreach (SceneItem sceneItem in response.Data.Data.SceneItems)
+                    {
+                        if (sceneItem.IsGroup.GetValueOrDefault())
+                        {
+                            string groupPacket = await SendAndWait(new OBSMessageGetGroupSceneItemListRequest(sceneItem.SourceName));
+                            if (!string.IsNullOrEmpty(groupPacket))
+                            {
+                                OBSMessageGetGroupSceneItemListResponse groupResponse = JSONSerializerHelper.DeserializeFromString<OBSMessageGetGroupSceneItemListResponse>(groupPacket);
+                                if (groupResponse?.Data?.Data != null)
+                                {
+                                    // Cache all items first
+                                    foreach (SceneItem groupSceneItem in groupResponse.Data.Data.SceneItems)
+                                    {
+                                        groupSceneItem.GroupName = sceneItem.SourceName;
+                                        sceneSourceNameToSceneItemDictionary[sceneName][groupSceneItem.SourceName] = groupSceneItem;
+                                    }
+
+                                    foreach (SceneItem groupSceneItem in groupResponse.Data.Data.SceneItems)
+                                    {
+                                        if (string.Equals(groupSceneItem.SourceName, sourceName, StringComparison.OrdinalIgnoreCase))
+                                        {
+                                            return groupSceneItem;
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            return null;
+        }
+
+        private async Task ProcessReceivedPacket(string packet)
+        {
+            try
+            {
+                Logger.Log(LogLevel.Debug, "OBS Studio packet received: " + packet);
+
+                OBSMessage message = JSONSerializerHelper.DeserializeFromString<OBSMessage>(packet);
+                switch (message.OpCode)
+                {
+                    case 0: // Hello
+                        await HandleHello(JSONSerializerHelper.DeserializeFromString<OBSMessageHello>(packet));
+                        break;
+                    case 2: // Identified
+                        this.identified = true;
+                        break;
+                    case 5: // Event
+                        HandleEvent(JSONSerializerHelper.DeserializeFromString<OBSMessageEvent>(packet));
+                        break;
+                    case 7: // Response
+                        HandleResponse(packet);
+                        break;
+                    default:
+                        System.Diagnostics.Debug.WriteLine(packet);
+                        break;
+                }
+            }
+            catch (Exception ex)
             {
                 Logger.Log(ex);
             }
         }
 
-        private bool IsConnectionException(Exception ex)
+        private void HandleResponse(string packet)
         {
-            if (ex == null)
+            OBSMessageResponse response = JSONSerializerHelper.DeserializeFromString<OBSMessageResponse>(packet);
+            if (responses.TryRemove(response.Data.RequestId, out var tcs))
             {
-                return false;
+                tcs.TrySetResult(packet);
             }
-
-            Exception current = this.GetInnermostException(ex);
-
-            if (current is TimeoutException || current is OperationCanceledException || current is WebSocketException)
-            {
-                return true;
-            }
-
-            if (current is InvalidOperationException && current.Message.IndexOf("WebSocket", StringComparison.OrdinalIgnoreCase) >= 0)
-            {
-                return true;
-            }
-
-            return false;
         }
 
-        private Exception GetInnermostException(Exception ex)
+        private void HandleEvent(OBSMessageEvent message)
         {
-            Exception current = ex;
-            if (current is AggregateException aggregate)
+            switch (message.Data.EventType)
             {
-                aggregate = aggregate.Flatten();
-                if (aggregate.InnerExceptions.Count > 0)
-                {
-                    current = aggregate.InnerExceptions[0];
-                }
+                case SceneNameChangedEvent:
+                    if (message.Data.Data.TryGetValue("oldSceneName", out var oldSceneName))
+                    {
+                        sceneSourceNameToSceneItemDictionary.TryRemove(oldSceneName?.ToString(), out _);
+                    }
+                    break;
+                case SceneItemRemovedEvent:
+                    if (message.Data.Data.TryGetValue("sceneName", out var removedSceneName) && message.Data.Data.TryGetValue("sourceName", out var removedSourceName))
+                    {
+                        if (sceneSourceNameToSceneItemDictionary.TryGetValue(removedSceneName?.ToString(), out var items))
+                        {
+                            items.TryRemove(removedSourceName?.ToString(), out _);
+                        }
+                    }
+                    break;
+                case InputRemovedEvent:
+                    if (message.Data.Data.TryGetValue("inputName", out var inputName))
+                    {
+                        foreach (var scene in sceneSourceNameToSceneItemDictionary.Keys.ToList())
+                        {
+                            if (sceneSourceNameToSceneItemDictionary.TryGetValue(scene, out var items))
+                            {
+                                items.TryRemove(inputName?.ToString(), out _);
+                            }
+                        }
+                    }
+                    break;
+                case InputNameChangedEvent:
+                    if (message.Data.Data.TryGetValue("oldInputName", out var oldInputName))
+                    {
+                        foreach (var scene in sceneSourceNameToSceneItemDictionary.Keys.ToList())
+                        {
+                            if (sceneSourceNameToSceneItemDictionary.TryGetValue(scene, out var items))
+                            {
+                                items.TryRemove(oldInputName?.ToString(), out _);
+                            }
+                        }
+                    }
+                    break;
             }
-
-            while (current.InnerException != null)
-            {
-                current = current.InnerException;
-            }
-
-            return current;
         }
 
-        private async Task WaitForConnectedState(TimeSpan timeout)
+        private async Task Send(OBSMessage message)
         {
-            DateTime deadline = DateTime.UtcNow.Add(timeout);
-            while (DateTime.UtcNow < deadline)
+            try
             {
-                if (this.OBSWebsocket.IsConnected)
-                {
-                    return;
-                }
+                await this.sendSemaphore.WaitAsync();
+                await base.Send(JsonConvert.SerializeObject(message));
+            }
+            catch (Exception ex)
+            {
+                Logger.Log(ex);
+            }
+            finally
+            {
+                this.sendSemaphore.Release();
+            }
+        }
 
-                await Task.Delay(100);
+        private async Task<string> SendAndWait(OBSMessageRequest request)
+        {
+            var tcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+            responses.TryAdd(request.Data.RequestId, tcs);
+            await Send(request);
+
+            using (CancellationTokenSource cts = new CancellationTokenSource(TimeSpan.FromSeconds(5)))
+            {
+                cts.Token.Register(() => tcs.TrySetCanceled());
+                try
+                {
+                    return await tcs.Task;
+                }
+                catch (TaskCanceledException)
+                {
+                    responses.TryRemove(request.Data.RequestId, out _);
+                    return null;
+                }
+            }
+        }
+
+        private void CancelAllRequests()
+        {
+            foreach (var kvp in responses.ToList())
+            {
+                if (responses.TryRemove(kvp.Key, out var tcs))
+                {
+                    tcs.TrySetCanceled();
+                }
+            }
+        }
+
+        private async Task HandleHello(OBSMessageHello message)
+        {
+            OBSMessageIdentify identify = new OBSMessageIdentify();
+            if (message?.Data?.Authentication != null)
+            {
+                // To generate the authentication string, follow these steps:
+                // Concatenate the websocket password with the salt provided by the server(password + salt)
+                string passwordAndSalt = this.password + message.Data.Authentication.Salt;
+
+                // Generate an SHA256 binary hash of the result and base64 encode it, known as a base64 secret.
+                using (SHA256 sha256Hash = SHA256.Create())
+                {
+                    byte[] bytes = sha256Hash.ComputeHash(Encoding.ASCII.GetBytes(passwordAndSalt));
+                    string base64Secret = Convert.ToBase64String(bytes);
+
+                    // Concatenate the base64 secret with the challenge sent by the server(base64_secret + challenge)
+                    string base64SecretAndChallenge = base64Secret + message.Data.Authentication.Challenge;
+
+                    // Generate a binary SHA256 hash of that result and base64 encode it. You now have your authentication string.
+                    bytes = sha256Hash.ComputeHash(Encoding.ASCII.GetBytes(base64SecretAndChallenge));
+                    identify.Data.Authentication = Convert.ToBase64String(bytes);
+                }
+            }
+            await Send(identify);
+        }
+
+        private class OBSMessage
+        {
+            [JsonProperty("op")]
+            public int OpCode { get; protected set; }
+        }
+
+        private class OBSMessage<T> : OBSMessage
+        {
+            [JsonProperty("d")]
+            public T Data { get; set; }
+        }
+
+        private class OBSMessageHello : OBSMessage<HelloData> { }
+
+        private class HelloData
+        {
+            [JsonProperty("obsWebSocketVersion")]
+            public string OBSWebSocketVersion { get; set; }
+
+            [JsonProperty("rpcVersion")]
+            public int RPCVersion { get; set; }
+
+            [JsonProperty("authentication")]
+            public HelloDataAuthentication Authentication { get; set; }
+        }
+
+        private class HelloDataAuthentication
+        {
+            [JsonProperty("challenge")]
+            public string Challenge { get; set; }
+
+            [JsonProperty("salt")]
+            public string Salt { get; set; }
+        }
+
+        private class OBSMessageIdentify : OBSMessage<IdentifyData>
+        {
+            public OBSMessageIdentify()
+            {
+                OpCode = 1;
+                Data = new IdentifyData
+                {
+                    RPCVersion = 1,
+                    EventSubscriptions = (1 << 2) | (1 << 3) | (1 << 7),   // Scene, Input, Scene Items events
+                };
+            }
+        }
+
+        private class IdentifyData
+        {
+            [JsonProperty("rpcVersion")]
+            public int RPCVersion { get; set; }
+
+            [JsonProperty("authentication")]
+            public string Authentication { get; set; }
+
+            [JsonProperty("eventSubscriptions")]
+            public ulong EventSubscriptions { get; set; }
+        }
+
+        private class OBSMessageIdentified : OBSMessage<IdentifiedData> { }
+
+        private class IdentifiedData
+        {
+            [JsonProperty("negotiatedRpcVersion")]
+            public string NegotiatedRpcVersion { get; set; }
+        }
+
+        private class OBSMessageEvent : OBSMessage<EventData> { }
+
+        private class EventData
+        {
+            [JsonProperty("eventType")]
+            public string EventType { get; set; }
+
+            [JsonProperty("eventIntent")]
+            public int EventIntent { get; set; }
+
+            [JsonProperty("eventData")]
+            public JObject Data { get; set; }
+        }
+
+        private class OBSMessageToggleStreamRequest : OBSMessageRequest
+        {
+            public OBSMessageToggleStreamRequest() : base() { this.Data.RequestType = "ToggleStream"; }
+        }
+
+        private class OBSMessageToggleRecordRequest : OBSMessageRequest
+        {
+            public OBSMessageToggleRecordRequest() : base() { this.Data.RequestType = "ToggleRecord"; }
+        }
+
+        private class OBSMessageStartReplayBufferRequest : OBSMessageRequest
+        {
+            public OBSMessageStartReplayBufferRequest() : base() { this.Data.RequestType = "StartReplayBuffer"; }
+        }
+
+        private class OBSMessageSaveReplayBufferRequest : OBSMessageRequest
+        {
+            public OBSMessageSaveReplayBufferRequest() : base() { this.Data.RequestType = "SaveReplayBuffer"; }
+        }
+
+        private class OBSMessageGetCurrentProgramSceneRequest : OBSMessageRequest
+        {
+            public OBSMessageGetCurrentProgramSceneRequest() : base() { this.Data.RequestType = "GetCurrentProgramScene"; }
+        }
+
+        private class OBSMessageGetCurrentProgramSceneResponse : OBSMessageResponse<GetCurrentProgramSceneData> { }
+
+        private class GetCurrentProgramSceneData
+        {
+            [JsonProperty("currentProgramSceneName")]
+            public string CurrentProgramSceneName { get; set; }
+        }
+
+        private class OBSMessageSetCurrentProgramSceneRequest : OBSMessageRequest<SetCurrentProgramSceneRequestData>
+        {
+            public OBSMessageSetCurrentProgramSceneRequest(string sceneName) : base()
+            {
+                this.Data.RequestType = "SetCurrentProgramScene";
+                this.Data.Data = new SetCurrentProgramSceneRequestData { SceneName = sceneName };
+            }
+        }
+
+        private class SetCurrentProgramSceneRequestData
+        {
+            [JsonProperty("sceneName")]
+            public string SceneName { get; set; }
+        }
+
+        private class OBSMessageSetCurrentSceneCollectionRequest : OBSMessageRequest<SetCurrentSceneCollectionData>
+        {
+            public OBSMessageSetCurrentSceneCollectionRequest(string sceneCollectionName) : base()
+            {
+                this.Data.RequestType = "SetCurrentSceneCollection";
+                this.Data.Data = new SetCurrentSceneCollectionData { SceneCollectionName = sceneCollectionName };
+            }
+        }
+
+        private class SetCurrentSceneCollectionData
+        {
+            [JsonProperty("sceneCollectionName")]
+            public string SceneCollectionName { get; set; }
+        }
+
+        private class OBSMessageGetSceneItemListRequest : OBSMessageRequest<GetSceneItemListRequestData>
+        {
+            public OBSMessageGetSceneItemListRequest(string sceneName) : base()
+            {
+                this.Data.RequestType = "GetSceneItemList";
+                this.Data.Data = new GetSceneItemListRequestData { SceneName = sceneName };
+            }
+        }
+
+        private class GetSceneItemListRequestData
+        {
+            [JsonProperty("sceneName")]
+            public string SceneName { get; set; }
+        }
+
+        private class OBSMessageGetSceneItemListResponse : OBSMessageResponse<GetSceneItemListResponseData> { }
+
+        private class GetSceneItemListResponseData
+        {
+            [JsonProperty("sceneItems")]
+            public SceneItem[] SceneItems { get; set; }
+        }
+
+        private class OBSMessageGetGroupSceneItemListRequest : OBSMessageRequest<GetGroupSceneItemListRequestData>
+        {
+            public OBSMessageGetGroupSceneItemListRequest(string groupName) : base()
+            {
+                this.Data.RequestType = "GetGroupSceneItemList";
+                this.Data.Data = new GetGroupSceneItemListRequestData { SceneName = groupName };
+            }
+        }
+
+        private class GetGroupSceneItemListRequestData
+        {
+            [JsonProperty("sceneName")]
+            public string SceneName { get; set; }
+        }
+
+        private class OBSMessageGetGroupSceneItemListResponse : OBSMessageResponse<GetGroupSceneItemListResponseData> { }
+
+        private class GetGroupSceneItemListResponseData
+        {
+            [JsonProperty("sceneItems")]
+            public SceneItem[] SceneItems { get; set; }
+        }
+
+        private class SceneItem
+        {
+            [JsonProperty("sceneItemId")]
+            public int SceneItemId { get; set; }
+
+            [JsonProperty("sourceName")]
+            public string SourceName { get; set; }
+
+            [JsonProperty("sceneItemTransform")]
+            public SceneItemTransform SceneItemTransform { get; set; }
+
+            [JsonProperty("isGroup")]
+            public bool? IsGroup { get; set; }
+
+            public string GroupName { get; set; }
+        }
+
+        private class SceneItemTransform
+        {
+            [JsonProperty("height")]
+            public float Height { get; set; }
+
+            [JsonProperty("positionX")]
+            public float PositionX { get; set; }
+
+            [JsonProperty("positionY")]
+            public float PositionY { get; set; }
+
+            [JsonProperty("rotation")]
+            public float Rotation { get; set; }
+
+            [JsonProperty("scaleX")]
+            public float ScaleX { get; set; }
+
+            [JsonProperty("scaleY")]
+            public float ScaleY { get; set; }
+
+            [JsonProperty("sourceHeight")]
+            public float SourceHeight { get; set; }
+
+            [JsonProperty("sourceWidth")]
+            public float SourceWidth { get; set; }
+
+            [JsonProperty("width")]
+            public float Width { get; set; }
+        }
+
+        private class OBSMessageSetSceneItemTransformRequest : OBSMessageRequest<SetSceneItemTransformRequestData>
+        {
+            public OBSMessageSetSceneItemTransformRequest(string sceneName, int sceneItemId, JObject sceneItemTransform) : base()
+            {
+                this.Data.RequestType = "SetSceneItemTransform";
+                this.Data.Data = new SetSceneItemTransformRequestData
+                {
+                    SceneName = sceneName,
+                    SceneItemId = sceneItemId,
+                    SceneItemTransform = sceneItemTransform,
+                };
+            }
+        }
+
+        private class SetSceneItemTransformRequestData
+        {
+            [JsonProperty("sceneName")]
+            public string SceneName { get; set; }
+
+            [JsonProperty("sceneItemId")]
+            public int SceneItemId { get; set; }
+
+            [JsonProperty("sceneItemTransform")]
+            public JObject SceneItemTransform { get; set; }
+        }
+
+        private class OBSMessageSetSceneItemEnabledRequest : OBSMessageRequest<SetSceneItemEnabledData>
+        {
+            public OBSMessageSetSceneItemEnabledRequest(string sceneName, int sceneItemId, bool sceneItemEnabled) : base()
+            {
+                this.Data.RequestType = "SetSceneItemEnabled";
+                this.Data.Data = new SetSceneItemEnabledData
+                {
+                    SceneName = sceneName,
+                    SceneItemId = sceneItemId,
+                    SceneItemEnabled = sceneItemEnabled,
+                };
+            }
+        }
+
+        private class SetSceneItemEnabledData
+        {
+            [JsonProperty("sceneName")]
+            public string SceneName { get; set; }
+
+            [JsonProperty("sceneItemId")]
+            public int SceneItemId { get; set; }
+
+            [JsonProperty("sceneItemEnabled")]
+            public bool SceneItemEnabled { get; set; }
+        }
+
+        private class OBSMessageGetInputSettingsRequest : OBSMessageRequest<GetInputSettingsData>
+        {
+            public OBSMessageGetInputSettingsRequest(string sourceName) : base()
+            {
+                this.Data.RequestType = "GetInputSettings";
+                this.Data.Data = new GetInputSettingsData { InputName = sourceName };
+            }
+        }
+
+        private class GetInputSettingsData
+        {
+            [JsonProperty("inputName")]
+            public string InputName { get; set; }
+        }
+
+        private class OBSMessageGetInputSettingsResponse : OBSMessageResponse<GetInputSettingsResponseData> { }
+
+        private class GetInputSettingsResponseData
+        {
+            [JsonProperty("inputSettings")]
+            public JObject InputSettings { get; set; }
+
+            [JsonProperty("inputKind")]
+            public string InputKind { get; set; }
+        }
+
+        private class OBSMessageSetInputSettingsRequest : OBSMessageRequest<SetInputSettingsData>
+        {
+            public OBSMessageSetInputSettingsRequest(string sourceName, JObject settings) : base()
+            {
+                this.Data.RequestType = "SetInputSettings";
+                this.Data.Data = new SetInputSettingsData
+                {
+                    InputName = sourceName,
+                    InputSettings = settings,
+                };
+            }
+        }
+
+        private class SetInputSettingsData
+        {
+            [JsonProperty("inputName")]
+            public string InputName { get; set; }
+
+            [JsonProperty("inputSettings")]
+            public JObject InputSettings { get; set; }
+        }
+
+        private class OBSMessageSetSourceFilterEnabledRequest : OBSMessageRequest<SetSourceFilterEnabledData>
+        {
+            public OBSMessageSetSourceFilterEnabledRequest(string sourceName, string filterName, bool filterEnabled) : base()
+            {
+                this.Data.RequestType = "SetSourceFilterEnabled";
+                this.Data.Data = new SetSourceFilterEnabledData
+                {
+                    SourceName = sourceName,
+                    FilterName = filterName,
+                    FilterEnabled = filterEnabled,
+                };
+            }
+        }
+
+        private class SetSourceFilterEnabledData
+        {
+            [JsonProperty("sourceName")]
+            public string SourceName { get; set; }
+
+            [JsonProperty("filterName")]
+            public string FilterName { get; set; }
+
+            [JsonProperty("filterEnabled")]
+            public bool FilterEnabled { get; set; }
+        }
+
+        private class OBSMessageRequest : OBSMessage<RequestData>
+        {
+            public OBSMessageRequest()
+            {
+                OpCode = 6;
+                this.Data = new RequestData { RequestId = Guid.NewGuid() };
+            }
+        }
+
+        private class OBSMessageRequest<T> : OBSMessageRequest
+        {
+            public new RequestData<T> Data
+            {
+                get => (RequestData<T>)base.Data;
+                private set => base.Data = value;
             }
 
-            throw new TimeoutException("OBS Studio connection timed out");
+            public OBSMessageRequest()
+            {
+                this.Data = new RequestData<T> { RequestId = Guid.NewGuid() };
+            }
+        }
+
+        private class RequestData
+        {
+            [JsonProperty("requestType")]
+            public string RequestType { get; set; }
+
+            [JsonProperty("requestId")]
+            public Guid RequestId { get; set; }
+        }
+
+        private class RequestData<T> : RequestData
+        {
+            [JsonProperty("requestData")]
+            public T Data { get; set; }
+        }
+
+        private class OBSMessageResponse : OBSMessage<ResponseData> { }
+
+        private class OBSMessageResponse<T> : OBSMessage<ResponseData<T>> { }
+
+        private class ResponseData
+        {
+            [JsonProperty("requestType")]
+            public string RequestType { get; set; }
+
+            [JsonProperty("requestId")]
+            public Guid RequestId { get; set; }
+
+            [JsonProperty("requestStatus")]
+            public RequestStatus Status { get; set; }
+        }
+
+        private class ResponseData<T> : ResponseData
+        {
+            [JsonProperty("responseData")]
+            public T Data { get; set; }
+        }
+
+        private class RequestStatus
+        {
+            [JsonProperty("result")]
+            public bool Result { get; set; }
+
+            [JsonProperty("code")]
+            public int Code { get; set; }
+
+            [JsonProperty("comment")]
+            public string Comment { get; set; }
         }
     }
 }

--- a/MixItUp.WPF/Services/WindowsOBSService.cs
+++ b/MixItUp.WPF/Services/WindowsOBSService.cs
@@ -229,6 +229,16 @@ namespace MixItUp.WPF.Services
             });
         }
 
+        public async Task SaveSourceScreenshot(string sourceName, string imageFormat, string imageFilePath, int? imageWidth, int? imageHeight)
+        {
+            Logger.Log(LogLevel.Debug, "Saving OBS Source screenshot - " + sourceName + " to " + imageFilePath);
+            await this.ExecuteOBSCommand(async () =>
+            {
+                await this.OBSWebsocketV5.SaveSourceScreenshot(sourceName, imageFormat, imageFilePath, imageWidth, imageHeight);
+                return true;
+            });
+        }
+
         private async Task<Result> ConnectInternal()
         {
             bool attemptedConnect = false;
@@ -577,6 +587,19 @@ namespace MixItUp.WPF.Services
                     {
                         return;
                     }
+                    throw new Exception(response.Data.Status.Comment);
+                }
+            }
+        }
+
+        public async Task SaveSourceScreenshot(string sourceName, string imageFormat, string imageFilePath, int? imageWidth, int? imageHeight)
+        {
+            string packet = await SendAndWait(new OBSMessageSaveSourceScreenshotRequest(sourceName, imageFormat, imageFilePath, imageWidth, imageHeight, -1));
+            if (!string.IsNullOrEmpty(packet))
+            {
+                OBSMessageResponse response = JSONSerializerHelper.DeserializeFromString<OBSMessageResponse>(packet);
+                if (response?.Data?.Status != null && !response.Data.Status.Result)
+                {
                     throw new Exception(response.Data.Status.Comment);
                 }
             }
@@ -1295,6 +1318,44 @@ namespace MixItUp.WPF.Services
 
             [JsonProperty("filterEnabled")]
             public bool FilterEnabled { get; set; }
+        }
+
+        private class OBSMessageSaveSourceScreenshotRequest : OBSMessageRequest<SaveSourceScreenshotRequestData>
+        {
+            public OBSMessageSaveSourceScreenshotRequest(string sourceName, string imageFormat, string imageFilePath, int? imageWidth, int? imageHeight, int? imageCompressionQuality) : base()
+            {
+                this.Data.RequestType = "SaveSourceScreenshot";
+                this.Data.Data = new SaveSourceScreenshotRequestData
+                {
+                    SourceName = sourceName,
+                    ImageFormat = imageFormat,
+                    ImageFilePath = imageFilePath,
+                    ImageWidth = imageWidth,
+                    ImageHeight = imageHeight,
+                    ImageCompressionQuality = imageCompressionQuality
+                };
+            }
+        }
+
+        private class SaveSourceScreenshotRequestData
+        {
+            [JsonProperty("sourceName")]
+            public string SourceName { get; set; }
+
+            [JsonProperty("imageFormat")]
+            public string ImageFormat { get; set; }
+
+            [JsonProperty("imageFilePath")]
+            public string ImageFilePath { get; set; }
+
+            [JsonProperty("imageWidth", NullValueHandling = NullValueHandling.Ignore)]
+            public int? ImageWidth { get; set; }
+
+            [JsonProperty("imageHeight", NullValueHandling = NullValueHandling.Ignore)]
+            public int? ImageHeight { get; set; }
+
+            [JsonProperty("imageCompressionQuality", NullValueHandling = NullValueHandling.Ignore)]
+            public int? ImageCompressionQuality { get; set; }
         }
 
         private class OBSMessageRequest : OBSMessage<RequestData>

--- a/MixItUp.WPF/UpdateWindow.xaml
+++ b/MixItUp.WPF/UpdateWindow.xaml
@@ -72,7 +72,7 @@
                         <TextBlock
                             VerticalAlignment="Center"
                             FontWeight="SemiBold"
-                            Text="This update is required to continue using Mix It Up" />
+                            Text="{x:Static resx:Resources.ThisUpdateIsRequired}" />
                     </StackPanel>
 
                     <StackPanel

--- a/MixItUp.WPF/UpdateWindow.xaml
+++ b/MixItUp.WPF/UpdateWindow.xaml
@@ -11,144 +11,207 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:resx="clr-namespace:MixItUp.Base;assembly=MixItUp.Base"
     Title="{x:Static resx:Resources.MixItUpUpdateAvailable}"
-    Width="600"
-    Height="650"
+    Width="775"
+    Height="700"
+    AllowsTransparency="True"
+    Background="Transparent"
     FontFamily="{MaterialDesign:MaterialDesignFont}"
-    Style="{StaticResource MaterialDesignWindow}"
+    ResizeMode="NoResize"
     TextElement.FontSize="14"
     TextElement.FontWeight="Medium"
+    WindowStyle="None"
     mc:Ignorable="d">
     <Grid>
-        <Grid.RowDefinitions>
-            <RowDefinition Height="*" />
-            <RowDefinition Height="Auto" />
-        </Grid.RowDefinitions>
-
-        <MaterialDesign:DialogHost x:Name="MDDialogHost" Identifier="RootDialog" />
-
-        <Grid Grid.Row="0" Margin="10,20,10,10">
-            <Grid.RowDefinitions>
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="15" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="20" />
-                <RowDefinition Height="*" />
-                <RowDefinition Height="20" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="20" />
-                <RowDefinition Height="Auto" />
-            </Grid.RowDefinitions>
-
-            <TextBlock
-                Grid.Row="0"
-                HorizontalAlignment="Center"
-                Text="{x:Static resx:Resources.ANewUpdateIsAvailableForMixItUp}" />
-
-            <Grid Grid.Row="2" HorizontalAlignment="Center">
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="Auto" />
-                </Grid.RowDefinitions>
-
-                <Grid Grid.Row="0" HorizontalAlignment="Center">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="Auto" />
-                        <ColumnDefinition Width="10" />
-                        <ColumnDefinition Width="Auto" />
-                        <ColumnDefinition Width="80" />
-                        <ColumnDefinition Width="Auto" />
-                        <ColumnDefinition Width="10" />
-                        <ColumnDefinition Width="Auto" />
-                    </Grid.ColumnDefinitions>
-
-                    <TextBlock
-                        Grid.Column="0"
-                        VerticalAlignment="Center"
-                        Text="{Binding Source={x:Static resx:Resources.NewVersion}, StringFormat={x:Static resx:Resources.ColumnHeaderFormat}}" />
-                    <TextBlock
-                        x:Name="NewVersionTextBlock"
-                        Grid.Column="2"
-                        VerticalAlignment="Center" />
-
-                    <TextBlock
-                        Grid.Column="4"
-                        VerticalAlignment="Center"
-                        Text="{Binding Source={x:Static resx:Resources.CurrentVersion}, StringFormat={x:Static resx:Resources.ColumnHeaderFormat}}" />
-                    <TextBlock
-                        x:Name="CurrentVersionTextBlock"
-                        Grid.Column="6"
-                        VerticalAlignment="Center" />
-                </Grid>
-
-                <Grid
-                    x:Name="PreviewUpdateGrid"
-                    Grid.Row="1"
-                    Margin="10,10,10,0"
-                    Visibility="Collapsed">
+        <MaterialDesign:DialogHost x:Name="MDDialogHost" Identifier="RootDialog">
+            <MaterialDesign:Card
+                Padding="30,30,30,0"
+                MaterialDesign:ElevationAssist.Elevation="Dp16"
+                Background="{DynamicResource MaterialDesign.Brush.Background}"
+                Foreground="{DynamicResource MaterialDesign.Brush.Foreground}"
+                UniformCornerRadius="16">
+                <Grid>
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto" />
-                        <RowDefinition Height="10" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="*" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />
                     </Grid.RowDefinitions>
 
-                    <TextBlock
+                    <Button
                         Grid.Row="0"
-                        Foreground="Red"
-                        Text="{x:Static resx:Resources.PreviewUpdateWarning1}"
-                        TextWrapping="Wrap" />
+                        Width="32"
+                        Height="32"
+                        Margin="0,-10,-10,0"
+                        HorizontalAlignment="Right"
+                        VerticalAlignment="Top"
+                        Click="CloseButton_Click"
+                        Style="{StaticResource MaterialDesignIconButton}"
+                        ToolTip="{x:Static resx:Resources.Close}">
+                        <MaterialDesign:PackIcon Width="20" Height="20" Kind="Close" />
+                    </Button>
+
+                    <StackPanel
+                        x:Name="MandatoryBanner"
+                        Grid.Row="1"
+                        Margin="0,0,0,15"
+                        HorizontalAlignment="Center"
+                        Orientation="Horizontal"
+                        Visibility="Collapsed">
+                        <MaterialDesign:PackIcon
+                            Width="20" Height="20"
+                            Margin="0,0,8,0"
+                            VerticalAlignment="Center"
+                            Foreground="{DynamicResource MaterialDesign.Brush.Primary}"
+                            Kind="AlertCircle" />
+                        <TextBlock
+                            VerticalAlignment="Center"
+                            FontWeight="SemiBold"
+                            Text="This update is required to continue using Mix It Up" />
+                    </StackPanel>
+
+                    <StackPanel
+                        Grid.Row="2"
+                        Margin="0,0,0,15"
+                        HorizontalAlignment="Center"
+                        Orientation="Horizontal">
+                        <TextBlock
+                            VerticalAlignment="Center"
+                            FontSize="22"
+                            FontWeight="SemiBold"
+                            Text="{x:Static resx:Resources.ANewUpdateIsAvailableForMixItUp}" />
+                    </StackPanel>
+
+                    <StackPanel
+                        Grid.Row="3"
+                        Margin="0,0,0,15"
+                        HorizontalAlignment="Center"
+                        Orientation="Horizontal">
+                        <Border
+                            BorderBrush="{DynamicResource MaterialDesignDivider}"
+                            BorderThickness="1"
+                            CornerRadius="6"
+                            Padding="12,6">
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock
+                                    VerticalAlignment="Center"
+                                    Opacity="0.7"
+                                    Text="{Binding Source={x:Static resx:Resources.CurrentVersion}, StringFormat={x:Static resx:Resources.ColumnHeaderFormat}}" />
+                                <TextBlock
+                                    x:Name="CurrentVersionTextBlock"
+                                    Margin="4,0,0,0"
+                                    VerticalAlignment="Center"
+                                    FontWeight="SemiBold" />
+                            </StackPanel>
+                        </Border>
+                        <MaterialDesign:PackIcon
+                            Width="24" Height="24"
+                            Margin="12,0"
+                            VerticalAlignment="Center"
+                            Foreground="{DynamicResource MaterialDesign.Brush.Primary}"
+                            Kind="ArrowRight" />
+                        <Border
+                            Background="{DynamicResource MaterialDesign.Brush.Primary}"
+                            CornerRadius="6"
+                            Padding="12,6">
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock
+                                    VerticalAlignment="Center"
+                                    Foreground="White"
+                                    Text="{Binding Source={x:Static resx:Resources.NewVersion}, StringFormat={x:Static resx:Resources.ColumnHeaderFormat}}" />
+                                <TextBlock
+                                    x:Name="NewVersionTextBlock"
+                                    Margin="4,0,0,0"
+                                    VerticalAlignment="Center"
+                                    FontWeight="SemiBold"
+                                    Foreground="White" />
+                            </StackPanel>
+                        </Border>
+                    </StackPanel>
+
+                    <Border
+                        x:Name="PreviewUpdateGrid"
+                        Grid.Row="4"
+                        Margin="0,0,0,10"
+                        Padding="12,8"
+                        BorderBrush="{DynamicResource MaterialDesignDivider}"
+                        BorderThickness="1"
+                        CornerRadius="8"
+                        Visibility="Collapsed">
+                        <StackPanel>
+                            <StackPanel Orientation="Horizontal">
+                                <MaterialDesign:PackIcon
+                                    Width="20" Height="20"
+                                    Margin="0,0,8,0"
+                                    VerticalAlignment="Top"
+                                    Foreground="{DynamicResource MaterialDesign.Brush.Primary}"
+                                    Kind="AlertOutline" />
+                                <TextBlock
+                                    Text="{x:Static resx:Resources.PreviewUpdateWarning1}"
+                                    TextWrapping="Wrap" />
+                            </StackPanel>
+                            <TextBlock
+                                Margin="28,6,0,0"
+                                Text="{x:Static resx:Resources.PreviewUpdateWarning2}"
+                                TextWrapping="Wrap" />
+                        </StackPanel>
+                    </Border>
+
+
+
+                    <Border
+                        Grid.Row="6"
+                        Margin="5,0"
+                        Padding="10"
+                        BorderBrush="{DynamicResource MaterialDesignDivider}"
+                        BorderThickness="1"
+                        CornerRadius="8">
+                        <markdown:MarkdownScrollViewer x:Name="UpdateChangelogViewer" />
+                    </Border>
+
+                    <StackPanel
+                        Grid.Row="7"
+                        Margin="0,20,0,0"
+                        HorizontalAlignment="Center"
+                        Orientation="Horizontal">
+                        <Button
+                            x:Name="DownloadUpdateButton"
+                            Height="40"
+                            MinWidth="130"
+                            Click="DownloadUpdateButton_Click"
+                            Content="{x:Static resx:Resources.Update}"
+                            Style="{StaticResource MaterialDesignRaisedButton}" />
+                        <Button
+                            x:Name="SkipUpdateButton"
+                            Height="40"
+                            MinWidth="100"
+                            Margin="20,0,0,0"
+                            Click="SkipUpdateButton_Click"
+                            Content="{x:Static resx:Resources.Skip}"
+                            Style="{StaticResource MaterialDesignOutlinedButton}"
+                            Visibility="Collapsed" />
+                    </StackPanel>
 
                     <TextBlock
-                        Grid.Row="2"
-                        Foreground="Red"
-                        Text="{x:Static resx:Resources.PreviewUpdateWarning2}"
+                        Grid.Row="8"
+                        Margin="0,15,0,15"
+                        HorizontalAlignment="Center"
+                        FontSize="12"
+                        Opacity="0.6"
+                        Text="{x:Static resx:Resources.IfUpdateDoesNotCompleteRestartComputer}"
                         TextWrapping="Wrap" />
+
+                    <Controls:LoadingStatusBar
+                        x:Name="StatusBar"
+                        Grid.Row="9"
+                        Margin="-30,10,-30,0" />
                 </Grid>
-            </Grid>
-
-            <markdown:MarkdownScrollViewer
-                x:Name="UpdateChangelogViewer"
-                Grid.Row="4"
-                Margin="20,0" />
-
-            <TextBlock
-                Grid.Row="6"
-                Width="500"
-                HorizontalAlignment="Center"
-                Text="{x:Static resx:Resources.IfUpdateDoesNotCompleteRestartComputer}"
-                TextWrapping="Wrap" />
-
-            <Grid Grid.Row="8" HorizontalAlignment="Center">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="Auto" />
-                    <ColumnDefinition Width="60" />
-                    <ColumnDefinition Width="Auto" />
-                    <ColumnDefinition Width="20" />
-                    <ColumnDefinition Width="Auto" />
-                </Grid.ColumnDefinitions>
-
-                <TextBlock
-                    Grid.Column="0"
-                    VerticalAlignment="Center"
-                    Text="{x:Static resx:Resources.WouldYouLikeToDownloadThisUpdate}" />
-
-                <Button
-                    x:Name="DownloadUpdateButton"
-                    Grid.Column="2"
-                    Click="DownloadUpdateButton_Click"
-                    Content="{x:Static resx:Resources.Update}"
-                    Style="{StaticResource MaterialDesignRaisedButton}" />
-
-                <Button
-                    x:Name="SkipUpdateButton"
-                    Grid.Column="4"
-                    Click="SkipUpdateButton_Click"
-                    Content="{x:Static resx:Resources.Skip}"
-                    Visibility="Collapsed" />
-
-            </Grid>
-
-        </Grid>
-
-        <Controls:LoadingStatusBar x:Name="StatusBar" Grid.Row="1" />
+            </MaterialDesign:Card>
+        </MaterialDesign:DialogHost>
     </Grid>
 </Windows:LoadingWindowBase>

--- a/MixItUp.WPF/UpdateWindow.xaml.cs
+++ b/MixItUp.WPF/UpdateWindow.xaml.cs
@@ -10,6 +10,7 @@ using System.Reflection;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Documents;
+using System.Windows.Input;
 using System.Windows.Navigation;
 
 namespace MixItUp.WPF
@@ -44,6 +45,11 @@ namespace MixItUp.WPF
 
             this.SkipUpdateButton.Visibility = this.update.Mandatory ? Visibility.Collapsed : Visibility.Visible;
             this.SkipUpdateButton.IsEnabled = !this.update.Mandatory;
+
+            if (this.update.Mandatory)
+            {
+                this.MandatoryBanner.Visibility = Visibility.Visible;
+            }
 
             try
             {
@@ -135,6 +141,24 @@ namespace MixItUp.WPF
         private void SkipUpdateButton_Click(object sender, RoutedEventArgs e)
         {
             this.Close();
+        }
+
+        private void CloseButton_Click(object sender, RoutedEventArgs e)
+        {
+            if (this.update.Mandatory)
+            {
+                Application.Current.Shutdown();
+            }
+            else
+            {
+                this.Close();
+            }
+        }
+
+        protected override void OnMouseLeftButtonDown(MouseButtonEventArgs e)
+        {
+            base.OnMouseLeftButtonDown(e);
+            this.DragMove();
         }
 
         private void AttachHyperlinkHandler()


### PR DESCRIPTION
- [MAINT] Update WebSocket error handling
- [MAINT] Remove pre-made headers for Web Request action
- [MAINT] Update Window redesign and improvements when handling mandatory updates
- [MAINT] Update Chagelog page to point to local file instead of external URL
- [FEAT] Add save source screenshot option to Streaming Software action (OBS Studio only)
- [FEAT] Add delete all quotes button
- [FIX] Additional OBS Studio WebSocket connectivity improvements and fix source visibility in groups
- [FIX] Renumbering quotes saving on app shutdown
- [FIX] Streamlabs Desktop source visibility fixed for dual output scenes
- [FIX] Crashes when receiving mass gifted subs, and fix total gifted tracking