### PR TITLE
v1.6.400 Release

### DIFF
--- a/APIs/MixItUp.API/MixItUp.API.csproj
+++ b/APIs/MixItUp.API/MixItUp.API.csproj
@@ -5,8 +5,8 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<AssemblyTitle>MixItUp.API</AssemblyTitle>
-    <AssemblyVersion>1.6.313.0</AssemblyVersion>
-    <FileVersion>1.6.313.0</FileVersion>
+    <AssemblyVersion>1.6.400.0</AssemblyVersion>
+    <FileVersion>1.6.400.0</FileVersion>
 		<Company>Blazing Cacti LLC</Company>
 		<Copyright>Copyright © 2026 Blazing Cacti LLC, All Rights Reserved. </Copyright>
 	</PropertyGroup>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,43 +1,40 @@
 # Mix It Up Desktop Changelog
 
-## 1.6.313
+## 1.6.400
 
-- [MAINT]: Refactor Websocket handling for various services (VTube Studio, Voicemod, Discord, T.I.T.S, VTSPog, and InfiniteAlbum)
-- [MAINT]: Update MIU Installer error logging and shortcut creation (release v0.7.0)
-- [FEAT]: Add Export Data button to inventory window
-- [FIX]: Various improvements to HTML/CSS/JS Overlay UI editors
-- [FIX]: Adjust mandatory update logic and update window
-- [FIX]: Streamlabs Desktop minor fix for Y Scale typo
-- [FIX]: Twitch gigantified emote $emoteurl
-
-## 1.6.312
-
-- [MAINT] Update WebSocket error handling
-- [MAINT] Remove pre-made headers for Web Request action
-- [MAINT] Update Window redesign and improvements when handling mandatory updates
-- [MAINT] Update Chagelog page to point to local file instead of external URL
-- [FEAT] Add save source screenshot option to Streaming Software action (OBS Studio only)
-- [FEAT] Add delete all quotes button
-- [FIX] Additional OBS Studio WebSocket connectivity improvements and fix source visibility in groups
-- [FIX] Renumbering quotes saving on app shutdown
-- [FIX] Streamlabs Desktop source visibility fixed for dual output scenes
-- [FIX] Crashes when receiving mass gifted subs, and fix total gifted tracking
-
-## 1.6.311
-
-- [MAINT] Significant improvements when opening the command editor and loading various actions
 - [MAINT] Update OBS Studio WebSocket V5 connections and stabilize reconnection logic *
 - [MAINT] Update Stream Elements service to new WebSocket server and remove deprecated Stream Elements Merch event **
+- [MAINT] Improve performance when opening commands with a large number of actions
 - [MAINT] Upgrade local authentication and overlay servers to Kestrel-based servers
 - [MAINT] Harden Stream Elements WebSocket reconnection and subscription flows
 - [MAINT] Improve WebSocket connections for various services
+- [MAINT] Update MIU Installer error logging and shortcut creation
+
+- [FEAT] Add Twitch Watch Streak event (supports $userwatchstreak and $watchstreakchannelpointsawarded)
+- [FEAT] Add new option Settings -> Commands to run Entrance Commands only when live
 - [FEAT] Add custom code editor for script action and overlay HTML/CSS/JS tabs in widgets and overlay actions
 - [FEAT] Add $twitchclipduration clip duration special identifier for Twitch clips playback in Overlay action
 - [FEAT] Add Years and Months to dateto() and datefrom() functions in special identifier action
 - [FEAT] Update branding in various places
+- [FEAT] Add Export Data button to inventory window
+- [FEAT] Add save source screenshot option to Streaming Software action (OBS Studio only)
+- [FEAT] Add delete all quotes button
+- [FEAT] Add custom refresh rate for leaderboard overlay widgets
+- [FEAT] Add reset button for persistent timer and persist timer amount between widget saves
+- [FEAT] Include user-only chat commands in the !commands pre-made command
+
+- [FIX] YouTube mass gifted memberships goal overlay and bonus currency
 - [FIX] Harden settings persistence to prevent settings loss in the case of a crash or power failure during a save operation
-- [FIX] Fix bug with Patreon account linking and losing subscriber status.
+- [FIX] Fix bug with Patreon account linking and losing subscriber status
 - [FIX] Fix crash when trying to edit Lumia Stream actions
+- [FIX] Add support for custom content-type and remove pre-made headers in Web Request Action
+- [FIX] Show full app history in changelog page
+- [FIX] Streamlabs Desktop minor fix for Y Scale typo
+- [FIX] Twitch gigantified emote $emoteurl
+- [FIX] Streamlabs Desktop source visibility fixed for dual output scenes
+- [FIX] Crashes when receiving mass gifted subs, and fix total gifted tracking
+- [FIX] Minor UI fixes across the application
+- [FIX] Persistent timer showing 0:00 when editing
 
 > **\* Legacy OBS WebSocket support (< v5.0) removed**  
 > **\*\* Test donations from SE Dashboard/Activity feed no longer triggers MIU SE Donation event**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,13 @@
 
 ## 1.6.313
 
-[MAINT]: Refactor Websocket handling for various services (VTube Studio, Voicemod, Discord, T.I.T.S, VTSPog, and InfiniteAlbum)
-[MAINT]: Update MIU Installer error logging and shortcut creation (release v0.7.0)
-[FEAT]: Add Export Data button to inventory window
-[FIX]: Various improvements to HTML/CSS/JS Overlay UI editors
-[FIX]: Adjust mandatory update logic and update window
-[FIX]: Streamlabs Desktop minor fix for Y Scale typo
-[FIX]: Twitch gigantified emote $emoteurl
+- [MAINT]: Refactor Websocket handling for various services (VTube Studio, Voicemod, Discord, T.I.T.S, VTSPog, and InfiniteAlbum)
+- [MAINT]: Update MIU Installer error logging and shortcut creation (release v0.7.0)
+- [FEAT]: Add Export Data button to inventory window
+- [FIX]: Various improvements to HTML/CSS/JS Overlay UI editors
+- [FIX]: Adjust mandatory update logic and update window
+- [FIX]: Streamlabs Desktop minor fix for Y Scale typo
+- [FIX]: Twitch gigantified emote $emoteurl
 
 ## 1.6.312
 

--- a/MixItUp.Base/MixItUp.Base.csproj
+++ b/MixItUp.Base/MixItUp.Base.csproj
@@ -3,8 +3,8 @@
   	<PropertyGroup>
 		<TargetFramework>net8.0</TargetFramework>
 		<AssemblyTitle>MixItUp.Base</AssemblyTitle>
-    <AssemblyVersion>1.6.313.0</AssemblyVersion>
-    <FileVersion>1.6.313.0</FileVersion>
+    <AssemblyVersion>1.6.400.0</AssemblyVersion>
+    <FileVersion>1.6.400.0</FileVersion>
 		<Company>Blazing Cacti LLC</Company>
 		<Copyright>Copyright © 2026 Blazing Cacti LLC, All Rights Reserved. </Copyright>
 	</PropertyGroup>

--- a/MixItUp.Base/Model/Actions/WebRequestActionModel.cs
+++ b/MixItUp.Base/Model/Actions/WebRequestActionModel.cs
@@ -84,11 +84,23 @@ namespace MixItUp.Base.Model.Actions
                 {
                     httpClient.DefaultRequestHeaders.Add("User-Agent", $"MixItUp/{Assembly.GetEntryAssembly().GetName().Version.ToString()} (Web call from Mix It Up; https://mixitupapp.com; support@mixitupapp.com)");
 
+                    string requestContentType = "application/json";
+
                     if (this.CustomHeaders != null)
                     {
                         foreach (var header in this.CustomHeaders)
                         {
                             string headerValue = await ReplaceStringWithSpecialModifiers(header.Value, parameters);
+
+                            if (string.Equals(header.Key, "Content-Type", StringComparison.OrdinalIgnoreCase))
+                            {
+                                if (!string.IsNullOrWhiteSpace(headerValue))
+                                {
+                                    requestContentType = headerValue;
+                                }
+                                continue;
+                            }
+
                             try
                             {
                                 httpClient.DefaultRequestHeaders.Add(header.Key, headerValue);
@@ -110,7 +122,7 @@ namespace MixItUp.Base.Model.Actions
                     if (!string.IsNullOrEmpty(this.RequestBody) && (this.HttpMethod == HttpMethodEnum.POST || this.HttpMethod == HttpMethodEnum.PUT))
                     {
                         string processedBody = await ReplaceStringWithSpecialModifiers(this.RequestBody, parameters);
-                        content = new StringContent(processedBody, Encoding.UTF8, "application/json");
+                        content = new StringContent(processedBody, Encoding.UTF8, requestContentType);
                     }
 
                     HttpResponseMessage response = null;
@@ -132,7 +144,7 @@ namespace MixItUp.Base.Model.Actions
 
                     using (response)
                     {
-                        if (string.Equals(response?.Content?.Headers?.ContentType?.CharSet, "utf8"))
+                        if (string.Equals(response?.Content?.Headers?.ContentType?.CharSet, "utf8", StringComparison.OrdinalIgnoreCase))
                         {
                             response.Content.Headers.ContentType.CharSet = "utf-8";
                         }

--- a/MixItUp.Base/Model/Commands/EventCommandModel.cs
+++ b/MixItUp.Base/Model/Commands/EventCommandModel.cs
@@ -88,6 +88,10 @@ namespace MixItUp.Base.Model.Commands
                     specialIdentifiers["usersubplan"] = "Tier 1";
                     specialIdentifiers["isanonymous"] = "false";
                     break;
+                case EventTypeEnum.TwitchChannelWatchStreak:
+                    specialIdentifiers["userwatchstreak"] = "5";
+                    specialIdentifiers["watchstreakchannelpointsawarded"] = "100";
+                    break;
 
                 case EventTypeEnum.TwitchChannelHighlightedMessage:
                     specialIdentifiers["message"] = "Test Message";

--- a/MixItUp.Base/Model/Commands/PreMadeChatCommandModels.cs
+++ b/MixItUp.Base/Model/Commands/PreMadeChatCommandModels.cs
@@ -88,28 +88,20 @@ namespace MixItUp.Base.Model.Commands
         {
             string groupFilter = (parameters.Arguments != null) ? string.Join(" ", parameters.Arguments) : null;
 
-            List<string> commandTriggers = new List<string>();
+            HashSet<string> commandTriggers = new HashSet<string>();
             foreach (ChatCommandModel command in ServiceManager.Get<CommandService>().AllEnabledChatAccessibleCommands)
             {
-                if (command.IsEnabled && !command.Wildcards)
-                {
-                    if (string.IsNullOrEmpty(groupFilter) || string.Equals(groupFilter, command.GroupName, StringComparison.OrdinalIgnoreCase))
-                    {
-                        RoleRequirementModel roleRequirement = command.Requirements.Role;
-                        if (roleRequirement != null)
-                        {
-                            Result result = await roleRequirement.Validate(parameters);
-                            if (result.Success)
-                            {
-                                string firstTrigger = command.Triggers.First();
-                                if (command.IncludeExclamation)
-                                {
-                                    firstTrigger = $"!{firstTrigger}";
-                                }
+                await this.AddCommandTrigger(commandTriggers, command, parameters, groupFilter);
+            }
 
-                                commandTriggers.Add(firstTrigger);
-                            }
-                        }
+            if (parameters.User != null && parameters.User.CustomCommandIDs.Count > 0)
+            {
+                foreach (Guid commandID in parameters.User.CustomCommandIDs)
+                {
+                    UserOnlyChatCommandModel command = ChannelSession.Settings.GetCommand<UserOnlyChatCommandModel>(commandID);
+                    if (command != null)
+                    {
+                        await this.AddCommandTrigger(commandTriggers, command, parameters, groupFilter);
                     }
                 }
             }
@@ -118,6 +110,31 @@ namespace MixItUp.Base.Model.Commands
             {
                 string text = MixItUp.Base.Resources.PreMadeChatCommandCommandsHeader + string.Join(", ", commandTriggers.OrderBy(c => c));
                 await ServiceManager.Get<ChatService>().SendMessage(text, parameters);
+            }
+        }
+
+        private async Task AddCommandTrigger(HashSet<string> commandTriggers, ChatCommandModel command, CommandParametersModel parameters, string groupFilter)
+        {
+            if (command.IsEnabled && !command.Wildcards)
+            {
+                if (string.IsNullOrEmpty(groupFilter) || string.Equals(groupFilter, command.GroupName, StringComparison.OrdinalIgnoreCase))
+                {
+                    RoleRequirementModel roleRequirement = command.Requirements.Role;
+                    if (roleRequirement != null)
+                    {
+                        Result result = await roleRequirement.Validate(parameters);
+                        if (result.Success)
+                        {
+                            string firstTrigger = command.Triggers.First();
+                            if (command.IncludeExclamation)
+                            {
+                                firstTrigger = $"!{firstTrigger}";
+                            }
+
+                            commandTriggers.Add(firstTrigger);
+                        }
+                    }
+                }
             }
         }
     }

--- a/MixItUp.Base/Model/Overlay/OverlayLeaderboardV3Model.cs
+++ b/MixItUp.Base/Model/Overlay/OverlayLeaderboardV3Model.cs
@@ -42,7 +42,7 @@ namespace MixItUp.Base.Model.Overlay
     public class OverlayLeaderboardV3Model : OverlayVisualTextV3ModelBase
     {
         public const string DetailsAmountPropertyName = "Amount";
-        public const int DefaultRefreshTime = 60;
+        public const int DefaultRefreshTimeSeconds = 60;
 
         public static readonly string DefaultHTML = OverlayResources.OverlayLeaderboardDefaultHTML;
         public static readonly string DefaultCSS = OverlayResources.OverlayLeaderboardDefaultCSS + Environment.NewLine + Environment.NewLine + OverlayResources.OverlayTextDefaultCSS + Environment.NewLine + Environment.NewLine + OverlayResources.OverlayHeaderTextDefaultCSS;
@@ -69,7 +69,7 @@ namespace MixItUp.Base.Model.Overlay
         public int TotalToShow { get; set; }
 
         [DataMember]
-        public int RefreshTime { get; set; }
+        public int RefreshTimeSeconds { get; set; }
 
         [DataMember]
         public OverlayAnimationV3Model ItemAddedAnimation { get; set; } = new OverlayAnimationV3Model();
@@ -77,25 +77,28 @@ namespace MixItUp.Base.Model.Overlay
         public OverlayAnimationV3Model ItemRemovedAnimation { get; set; } = new OverlayAnimationV3Model();
 
         private CancellationTokenSource cancellationTokenSource;
+        private string lastLeaderboardState;
 
         public OverlayLeaderboardV3Model() : base(OverlayItemV3Type.Leaderboard)
         {
-            this.RefreshTime = DefaultRefreshTime;
+            this.RefreshTimeSeconds = DefaultRefreshTimeSeconds;
         }
 
         public async Task ClearLeaderboard()
         {
+            this.lastLeaderboardState = null;
             await this.CallFunction("clear", new Dictionary<string, object>());
         }
 
         public async Task UpdateLeaderboard(IEnumerable<Tuple<UserV2ViewModel, long>> users)
         {
-            if (users == null || users.Count() == 0)
+            if (users == null)
             {
                 return;
             }
 
             JArray jarr = new JArray();
+            List<string> leaderboardState = new List<string>();
 
             foreach (var kvp in users.Take(this.TotalToShow))
             {
@@ -108,6 +111,25 @@ namespace MixItUp.Base.Model.Overlay
                 jobj[UserProperty] = JObject.FromObject(kvp.Item1);
                 jobj["Details"] = kvp.Item2;
                 jarr.Add(jobj);
+
+                if (kvp.Item1 != null)
+                {
+                    leaderboardState.Add($"{kvp.Item1.ID}:{kvp.Item2}");
+                }
+            }
+
+            string currentLeaderboardState = string.Join("|", leaderboardState);
+            if (string.Equals(this.lastLeaderboardState, currentLeaderboardState))
+            {
+                return;
+            }
+
+            await this.ClearLeaderboard();
+            this.lastLeaderboardState = currentLeaderboardState;
+
+            if (jarr.Count == 0)
+            {
+                return;
             }
 
             Dictionary<string, object> data = new Dictionary<string, object>();
@@ -142,6 +164,8 @@ namespace MixItUp.Base.Model.Overlay
                 this.cancellationTokenSource.Cancel();
                 this.cancellationTokenSource = null;
             }
+
+            this.lastLeaderboardState = null;
         }
 
         protected override Task Loaded()
@@ -153,7 +177,8 @@ namespace MixItUp.Base.Model.Overlay
             }
 
             this.cancellationTokenSource = new CancellationTokenSource();
-            int refreshTimeMilliseconds = 1000 * ((this.RefreshTime > 0) ? this.RefreshTime : DefaultRefreshTime);
+            this.lastLeaderboardState = null;
+            int refreshTimeMilliseconds = 1000 * ((this.RefreshTimeSeconds > 0) ? this.RefreshTimeSeconds : DefaultRefreshTimeSeconds);
 #pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
             if (this.LeaderboardType == OverlayLeaderboardTypeV3Enum.ViewingTime)
             {

--- a/MixItUp.Base/Model/Overlay/OverlayLeaderboardV3Model.cs
+++ b/MixItUp.Base/Model/Overlay/OverlayLeaderboardV3Model.cs
@@ -42,6 +42,7 @@ namespace MixItUp.Base.Model.Overlay
     public class OverlayLeaderboardV3Model : OverlayVisualTextV3ModelBase
     {
         public const string DetailsAmountPropertyName = "Amount";
+        public const int DefaultRefreshTime = 60;
 
         public static readonly string DefaultHTML = OverlayResources.OverlayLeaderboardDefaultHTML;
         public static readonly string DefaultCSS = OverlayResources.OverlayLeaderboardDefaultCSS + Environment.NewLine + Environment.NewLine + OverlayResources.OverlayTextDefaultCSS + Environment.NewLine + Environment.NewLine + OverlayResources.OverlayHeaderTextDefaultCSS;
@@ -68,13 +69,19 @@ namespace MixItUp.Base.Model.Overlay
         public int TotalToShow { get; set; }
 
         [DataMember]
+        public int RefreshTime { get; set; }
+
+        [DataMember]
         public OverlayAnimationV3Model ItemAddedAnimation { get; set; } = new OverlayAnimationV3Model();
         [DataMember]
         public OverlayAnimationV3Model ItemRemovedAnimation { get; set; } = new OverlayAnimationV3Model();
 
         private CancellationTokenSource cancellationTokenSource;
 
-        public OverlayLeaderboardV3Model() : base(OverlayItemV3Type.Leaderboard) { }
+        public OverlayLeaderboardV3Model() : base(OverlayItemV3Type.Leaderboard)
+        {
+            this.RefreshTime = DefaultRefreshTime;
+        }
 
         public async Task ClearLeaderboard()
         {
@@ -146,22 +153,22 @@ namespace MixItUp.Base.Model.Overlay
             }
 
             this.cancellationTokenSource = new CancellationTokenSource();
+            int refreshTimeMilliseconds = 1000 * ((this.RefreshTime > 0) ? this.RefreshTime : DefaultRefreshTime);
 #pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
             if (this.LeaderboardType == OverlayLeaderboardTypeV3Enum.ViewingTime)
             {
-                AsyncRunner.RunAsyncBackground(this.ViewingTimeBackgroundTask, this.cancellationTokenSource.Token, 60000);
+                AsyncRunner.RunAsyncBackground(this.ViewingTimeBackgroundTask, this.cancellationTokenSource.Token, refreshTimeMilliseconds);
             }
             else if (this.LeaderboardType == OverlayLeaderboardTypeV3Enum.Consumable)
             {
-                if (ChannelSession.Settings.Currency.TryGetValue(this.ConsumableID, out var currency))
+                if (ChannelSession.Settings.Currency.ContainsKey(this.ConsumableID))
                 {
-                    int interval = (currency.AcquireInterval > 0) ? currency.AcquireInterval : 1;
-                    AsyncRunner.RunAsyncBackground(this.ConsumableBackgroundTask, this.cancellationTokenSource.Token, interval * 60000);
+                    AsyncRunner.RunAsyncBackground(this.ConsumableBackgroundTask, this.cancellationTokenSource.Token, refreshTimeMilliseconds);
                 }
             }
             else if (this.LeaderboardType == OverlayLeaderboardTypeV3Enum.TwitchBits)
             {
-                AsyncRunner.RunAsyncBackground(this.TwitchBitsBackgroundTask, this.cancellationTokenSource.Token, 60000);
+                AsyncRunner.RunAsyncBackground(this.TwitchBitsBackgroundTask, this.cancellationTokenSource.Token, refreshTimeMilliseconds);
             }
 #pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
 

--- a/MixItUp.Base/Model/Overlay/OverlayPersistentTimerV3Model.cs
+++ b/MixItUp.Base/Model/Overlay/OverlayPersistentTimerV3Model.cs
@@ -1,4 +1,4 @@
-﻿using MixItUp.Base.Model.Commands;
+using MixItUp.Base.Model.Commands;
 using MixItUp.Base.Model.Overlay.Widgets;
 using MixItUp.Base.Services;
 using MixItUp.Base.Util;
@@ -60,6 +60,8 @@ namespace MixItUp.Base.Model.Overlay
 
         [JsonIgnore]
         private object amountLock = new object();
+
+        public override bool IsResettable { get { return true; } }
 
         public OverlayPersistentTimerV3Model() : base(OverlayItemV3Type.PersistentTimer) { }
 

--- a/MixItUp.Base/Model/Twitch/EventSub/ChatNotification.cs
+++ b/MixItUp.Base/Model/Twitch/EventSub/ChatNotification.cs
@@ -19,6 +19,7 @@ namespace MixItUp.Base.Model.Twitch.EventSub
         announcement,
         bits_badge_tier,
         charity_donation,
+        watch_streak,
         shared_chat_sub,
         shared_chat_resub,
         shared_chat_sub_gift,
@@ -56,6 +57,7 @@ namespace MixItUp.Base.Model.Twitch.EventSub
         public ChatNotificationAnnouncement announcement { get; set; }
         public ChatNotificationBitsBadgeTier bits_badge_tier { get; set; }
         public ChatNotificationCharityDonation charity_donation { get; set; }
+        public ChatNotificationWatchStreak watch_streak { get; set; }
         public ChatNotificationSub shared_chat_sub { get; set; }
         public ChatNotificationResub shared_chat_resub { get; set; }
         public ChatNotificationSubGift shared_chat_sub_gift { get; set; }
@@ -179,6 +181,12 @@ namespace MixItUp.Base.Model.Twitch.EventSub
     {
         public string charity_name { get; set; }
         public ChatNotificationCharityDonationAmount amount { get; set; }
+    }
+
+    public class ChatNotificationWatchStreak
+    {
+        public int? streak_count { get; set; }
+        public int? channel_points_awarded { get; set; }
     }
 
     public class ChatNotificationCharityDonationAmount

--- a/MixItUp.Base/OverlayResources.Designer.cs
+++ b/MixItUp.Base/OverlayResources.Designer.cs
@@ -1189,7 +1189,7 @@ namespace MixItUp.Base {
         ///&lt;head&gt;
         ///    &lt;meta charset=&quot;utf-8&quot; /&gt;
         ///    &lt;title&gt;Mix It Up - Overlay&lt;/title&gt;
-        ///    &lt;link rel=&quot;icon&quot; type=&quot;image/x-icon&quot; href=&quot;https://mixitupapp.com/favicon.ico&quot;&gt;
+        ///    &lt;link rel=&quot;icon&quot; type=&quot;image/x-icon&quot; href=&quot;https://files.mixitupapp.com/static/branding/mixitup.ico&quot;&gt;
         ///
         ///    &lt;script&gt;
         ///        var connection;
@@ -1199,7 +1199,7 @@ namespace MixItUp.Base {
         ///            openWebsocketConnectionWithAddressPort(window.location.hostname, window.location.port, path);
         ///        }
         ///
-        ///        function openWebsocketCo [rest of string was truncated]&quot;;.
+        ///        fu [rest of string was truncated]&quot;;.
         /// </summary>
         public static string OverlayMainHTML {
             get {

--- a/MixItUp.Base/OverlayResources.resx
+++ b/MixItUp.Base/OverlayResources.resx
@@ -1979,7 +1979,7 @@ sendParentMessage({ Type: "WidgetLoaded", ID: "{ID}" });</value>
 &lt;head&gt;
     &lt;meta charset="utf-8" /&gt;
     &lt;title&gt;Mix It Up - Overlay&lt;/title&gt;
-    &lt;link rel="icon" type="image/x-icon" href="https://mixitupapp.com/favicon.ico"&gt;
+    &lt;link rel="icon" type="image/x-icon" href="https://files.mixitupapp.com/static/branding/mixitup.ico"&gt;
 
     &lt;script&gt;
         var connection;

--- a/MixItUp.Base/Services/ChatService.cs
+++ b/MixItUp.Base/Services/ChatService.cs
@@ -594,10 +594,10 @@ namespace MixItUp.Base.Services
 
                         if (!this.userEntranceCommands.Contains(message.User.ID))
                         {
-                            this.userEntranceCommands.Add(message.User.ID);
-
                             if (!ChannelSession.Settings.UserEntranceCommandsOnlyWhenLive || StreamingPlatforms.GetPlatformSession(message.User.Platform).IsLive)
                             {
+                                this.userEntranceCommands.Add(message.User.ID);
+
                                 CommandModelBase customEntranceCommand = ChannelSession.Settings.GetCommand(message.User.EntranceCommandID);
                                 if (customEntranceCommand != null && customEntranceCommand.IsEnabled)
                                 {

--- a/MixItUp.Base/Services/EventService.cs
+++ b/MixItUp.Base/Services/EventService.cs
@@ -70,7 +70,6 @@ namespace MixItUp.Base.Services
         TwitchChannelSubscriptionGifted = 222,
         TwitchChannelMassSubscriptionsGifted = 223,
 
-        [Obsolete]
         TwitchChannelWatchStreak = 230,
 
         TwitchChannelHighlightedMessage = 240,

--- a/MixItUp.Base/Services/External/TikTokTTSService.cs
+++ b/MixItUp.Base/Services/External/TikTokTTSService.cs
@@ -16,7 +16,7 @@ namespace MixItUp.Base.Services.External
     {
         public static readonly IEnumerable<TextToSpeechVoice> AvailableVoices = new List<TextToSpeechVoice>()
 {
-    new TextToSpeechVoice("en_us_001", "English US - Female"),
+new TextToSpeechVoice("en_us_001", "English US - Female"),
     new TextToSpeechVoice("en_us_006", "English US - Male 1"),
     new TextToSpeechVoice("en_us_007", "English US - Male 2"),
     new TextToSpeechVoice("en_us_009", "English US - Male 3"),
@@ -46,6 +46,9 @@ namespace MixItUp.Base.Services.External
     new TextToSpeechVoice("br_004", "Portuguese BR - Female 3"),
     new TextToSpeechVoice("br_005", "Portuguese BR - Male"),
 
+    new TextToSpeechVoice("pt_female_lhays", "Lhays Macedo (Portuguese)"),
+    new TextToSpeechVoice("pt_female_laizza", "Laizza (Portuguese)"),
+
     new TextToSpeechVoice("id_001", "Indonesian - Female"),
 
     new TextToSpeechVoice("jp_001", "Japanese - Female 1"),
@@ -56,6 +59,9 @@ namespace MixItUp.Base.Services.External
     new TextToSpeechVoice("kr_002", "Korean - Male 1"),
     new TextToSpeechVoice("kr_004", "Korean - Male 2"),
     new TextToSpeechVoice("kr_003", "Korean - Female"),
+
+    new TextToSpeechVoice("BV074_streaming", "Vietnamese - Female"),
+    new TextToSpeechVoice("BV075_streaming", "Vietnamese - Male"),
 
     new TextToSpeechVoice("en_female_f08_salut_damour", "Alto"),
     new TextToSpeechVoice("en_male_m2_xhxs_m03_silly", "Chipmunk"),
@@ -78,7 +84,42 @@ namespace MixItUp.Base.Services.External
     new TextToSpeechVoice("en_male_narration", "Narrator"),
     new TextToSpeechVoice("en_male_funny", "Wacky"),
     new TextToSpeechVoice("en_female_emotional", "Peaceful"),
-    new TextToSpeechVoice("en_male_cody", "Serious")
+    new TextToSpeechVoice("en_male_cody", "Serious"),
+
+    new TextToSpeechVoice("en_male_jomboy", "Game On"),
+    new TextToSpeechVoice("en_female_samc", "Empathetic"),
+    new TextToSpeechVoice("en_female_makeup", "Beauty Guru"),
+    new TextToSpeechVoice("en_female_richgirl", "Bestie"),
+    new TextToSpeechVoice("en_male_grinch", "Trickster"),
+    new TextToSpeechVoice("en_male_deadpool", "Mr. GoodGuy"),
+    new TextToSpeechVoice("en_male_jarvis", "Alfred"),
+    new TextToSpeechVoice("en_male_ashmagic", "Ashmagic"),
+    new TextToSpeechVoice("en_male_olantekkers", "Olantekkers"),
+    new TextToSpeechVoice("en_male_ukneighbor", "Lord Cringe"),
+    new TextToSpeechVoice("en_male_ukbutler", "Mr. Meticulous"),
+    new TextToSpeechVoice("en_female_shenna", "Debutante"),
+    new TextToSpeechVoice("en_female_pansino", "Varsity"),
+    new TextToSpeechVoice("en_male_trevor", "Marty"),
+    new TextToSpeechVoice("en_female_f08_twinkle", "Pop Lullaby"),
+    new TextToSpeechVoice("en_male_m03_classical", "Classic Electric"),
+    new TextToSpeechVoice("en_female_betty", "Bae"),
+    new TextToSpeechVoice("en_male_cupid", "Cupid"),
+    new TextToSpeechVoice("en_female_grandma", "Granny"),
+    new TextToSpeechVoice("en_male_m2_xhxs_m03_christmas", "Cozy"),
+    new TextToSpeechVoice("en_male_santa_narration", "Author"),
+    new TextToSpeechVoice("en_male_santa_effect", "Santa"),
+    new TextToSpeechVoice("en_male_wizard", "Magician"),
+
+
+    new TextToSpeechVoice("jp_female_yagishaki", "八木沙季"),
+    new TextToSpeechVoice("jp_male_hikakin", "ヒカキン"),
+    new TextToSpeechVoice("jp_female_rei", "丸山礼"),
+    new TextToSpeechVoice("jp_male_shuichiro", "修一朗"),
+    new TextToSpeechVoice("jp_male_matsudake", "マツダ家の日常"),
+    new TextToSpeechVoice("jp_female_machikoriiita", "まちこりーた"),
+    new TextToSpeechVoice("jp_male_osada", "モリスケ"),
+
+
 };
 
         public TextToSpeechProviderType ProviderType { get { return TextToSpeechProviderType.TikTokTTS; } }

--- a/MixItUp.Base/Services/External/TikTokTTSService.cs
+++ b/MixItUp.Base/Services/External/TikTokTTSService.cs
@@ -57,14 +57,15 @@ namespace MixItUp.Base.Services.External
     new TextToSpeechVoice("kr_004", "Korean - Male 2"),
     new TextToSpeechVoice("kr_003", "Korean - Female"),
 
-    new TextToSpeechVoice("en_female_f08_salut_damour", "Alto"),
-    new TextToSpeechVoice("en_male_m2_xhxs_m03_silly", "Chipmunk"),
-    new TextToSpeechVoice("en_female_ht_f08_wonderful_world", "Dramatic"),
-    new TextToSpeechVoice("en_female_ht_f08_glorious", "Glorious"),
-    new TextToSpeechVoice("en_male_sing_funny_it_goes_up", "It Goes Up"),
-    new TextToSpeechVoice("en_male_m03_sunshine_soon", "Sunshine Soon"),
-    new TextToSpeechVoice("en_male_m03_lobby", "Tenor"),
-    new TextToSpeechVoice("en_female_f08_warmy_breeze", "Warmy Breeze"),
+    // Stopped working as of April 01, 2026 by TikTok
+    //new TextToSpeechVoice("en_female_f08_salut_damour", "Alto"),
+    //new TextToSpeechVoice("en_male_m2_xhxs_m03_silly", "Chipmunk"),
+    //new TextToSpeechVoice("en_female_ht_f08_wonderful_world", "Dramatic"),
+    //new TextToSpeechVoice("en_female_ht_f08_glorious", "Glorious"),
+    //new TextToSpeechVoice("en_male_sing_funny_it_goes_up", "It Goes Up"),
+    //new TextToSpeechVoice("en_male_m03_sunshine_soon", "Sunshine Soon"),
+    //new TextToSpeechVoice("en_male_m03_lobby", "Tenor"),
+    //new TextToSpeechVoice("en_female_f08_warmy_breeze", "Warmy Breeze"),
 
     new TextToSpeechVoice("en_us_c3po", "C3PO (Star Wars)"),
     new TextToSpeechVoice("en_us_chewbacca", "Chewbacca (Star Wars)"),

--- a/MixItUp.Base/Services/External/TikTokTTSService.cs
+++ b/MixItUp.Base/Services/External/TikTokTTSService.cs
@@ -57,15 +57,14 @@ namespace MixItUp.Base.Services.External
     new TextToSpeechVoice("kr_004", "Korean - Male 2"),
     new TextToSpeechVoice("kr_003", "Korean - Female"),
 
-    // Stopped working as of April 01, 2026 by TikTok
-    //new TextToSpeechVoice("en_female_f08_salut_damour", "Alto"),
-    //new TextToSpeechVoice("en_male_m2_xhxs_m03_silly", "Chipmunk"),
-    //new TextToSpeechVoice("en_female_ht_f08_wonderful_world", "Dramatic"),
-    //new TextToSpeechVoice("en_female_ht_f08_glorious", "Glorious"),
-    //new TextToSpeechVoice("en_male_sing_funny_it_goes_up", "It Goes Up"),
-    //new TextToSpeechVoice("en_male_m03_sunshine_soon", "Sunshine Soon"),
-    //new TextToSpeechVoice("en_male_m03_lobby", "Tenor"),
-    //new TextToSpeechVoice("en_female_f08_warmy_breeze", "Warmy Breeze"),
+    new TextToSpeechVoice("en_female_f08_salut_damour", "Alto"),
+    new TextToSpeechVoice("en_male_m2_xhxs_m03_silly", "Chipmunk"),
+    new TextToSpeechVoice("en_female_ht_f08_wonderful_world", "Dramatic"),
+    new TextToSpeechVoice("en_female_ht_f08_glorious", "Glorious"),
+    new TextToSpeechVoice("en_male_sing_funny_it_goes_up", "It Goes Up"),
+    new TextToSpeechVoice("en_male_m03_sunshine_soon", "Sunshine Soon"),
+    new TextToSpeechVoice("en_male_m03_lobby", "Tenor"),
+    new TextToSpeechVoice("en_female_f08_warmy_breeze", "Warmy Breeze"),
 
     new TextToSpeechVoice("en_us_c3po", "C3PO (Star Wars)"),
     new TextToSpeechVoice("en_us_chewbacca", "Chewbacca (Star Wars)"),

--- a/MixItUp.Base/Services/Twitch/New/TwitchClient.cs
+++ b/MixItUp.Base/Services/Twitch/New/TwitchClient.cs
@@ -940,6 +940,14 @@ namespace MixItUp.Base.Services.Twitch.New
             await ServiceManager.Get<ChatService>().DeleteMessage(messageDeleted.message_id);
         }
 
+        private async Task HandleWatchStreak(UserV2ViewModel user, ChatNotification notification)
+        {
+            CommandParametersModel parameters = new CommandParametersModel(user, StreamingPlatformTypeEnum.Twitch);
+            parameters.SpecialIdentifiers["userwatchstreak"] = notification.watch_streak.streak_count.GetValueOrDefault().ToString();
+            parameters.SpecialIdentifiers["watchstreakchannelpointsawarded"] = notification.watch_streak.channel_points_awarded.GetValueOrDefault().ToString();
+            await ServiceManager.Get<EventService>().PerformEvent(EventTypeEnum.TwitchChannelWatchStreak, parameters);
+        }
+
         private async Task HandleChatNotification(JObject payload)
         {
             ChatNotification notification = payload.ToObject<ChatNotification>();
@@ -965,6 +973,10 @@ namespace MixItUp.Base.Services.Twitch.New
             {
                 TwitchChatMessageViewModel message = new TwitchChatMessageViewModel(notification, user);
                 await ServiceManager.Get<ChatService>().AddMessage(message);
+            }
+            else if (notification.NoticeType == ChatNotificationType.watch_streak)
+            {
+                await this.HandleWatchStreak(user, notification);
             }
 
             // Subs

--- a/MixItUp.Base/Services/Twitch/New/TwitchSession.cs
+++ b/MixItUp.Base/Services/Twitch/New/TwitchSession.cs
@@ -675,6 +675,9 @@ namespace MixItUp.Base.Services.Twitch.New
                     tempMassGiftedSubs.AddRange(this.pendingMassGiftedSubs.ToList().OrderBy(s => s.Processed));
                 }
 
+                List<TwitchSubcriptionEventModel> giftedSubsToRetry = new List<TwitchSubcriptionEventModel>();
+                DateTimeOffset now = DateTimeOffset.Now;
+
                 foreach (var giftedSub in tempGiftedSubs)
                 {
                     TwitchMassGiftedSubcriptionsEventModel massGiftedSub = null;
@@ -705,7 +708,22 @@ namespace MixItUp.Base.Services.Twitch.New
                     }
                     else
                     {
-                        await ProcessGiftedSub(giftedSub);
+                        if ((now - giftedSub.Processed).TotalMilliseconds >= 1500)
+                        {
+                            await ProcessGiftedSub(giftedSub);
+                        }
+                        else
+                        {
+                            giftedSubsToRetry.Add(giftedSub);
+                        }
+                    }
+                }
+
+                if (giftedSubsToRetry.Count > 0)
+                {
+                    lock (this.pendingGiftedSubs)
+                    {
+                        this.pendingGiftedSubs.AddRange(giftedSubsToRetry);
                     }
                 }
             }

--- a/MixItUp.Base/Services/YouTube/New/YouTubeSession.cs
+++ b/MixItUp.Base/Services/YouTube/New/YouTubeSession.cs
@@ -1,4 +1,4 @@
-﻿using Google.Apis.YouTube.v3.Data;
+using Google.Apis.YouTube.v3.Data;
 using MixItUp.Base.Model;
 using MixItUp.Base.Model.Commands;
 using MixItUp.Base.Model.Currency;
@@ -654,10 +654,7 @@ namespace MixItUp.Base.Services.YouTube.New
 
                             foreach (CurrencyModel currency in ChannelSession.Settings.Currency.Values)
                             {
-                                for (int i = 0; i < membershipsGifted.Amount; i++)
-                                {
-                                    currency.AddAmount(user, currency.OnSubscribeBonus * membershipsGifted.Amount);
-                                }
+                                currency.AddAmount(user, currency.OnSubscribeBonus * membershipsGifted.Amount);
                             }
 
                             foreach (StreamPassModel streamPass in ChannelSession.Settings.StreamPass.Values)
@@ -675,6 +672,13 @@ namespace MixItUp.Base.Services.YouTube.New
                             await ServiceManager.Get<EventService>().PerformEvent(EventTypeEnum.YouTubeChannelMassMembershipGifted, parameters);
 
                             await ServiceManager.Get<AlertsService>().AddAlert(new AlertChatMessageViewModel(user, string.Format(MixItUp.Base.Resources.AlertMassSubscriptionsGiftedTier, user.FullDisplayName, membershipsGifted.Amount, membershipsGifted.Tier), ChannelSession.Settings.AlertMassGiftedSubColor));
+
+                            List<SubscriptionDetailsModel> subscriptions = new List<SubscriptionDetailsModel>();
+                            for (int i = 0; i < membershipsGifted.Amount; i++)
+                            {
+                                subscriptions.Add(new SubscriptionDetailsModel(StreamingPlatformTypeEnum.YouTube, user, youTubeMembershipTier: membershipsGifted.Tier));
+                            }
+                            EventService.MassSubscriptionsGiftedOccurred(subscriptions);
                         }
                     }
                     else if (GiftMembershipReceivedEventMessageType.Equals(liveChatMessage.Snippet.Type))

--- a/MixItUp.Base/ViewModel/MainControls/EventsMainControlViewModel.cs
+++ b/MixItUp.Base/ViewModel/MainControls/EventsMainControlViewModel.cs
@@ -163,6 +163,7 @@ namespace MixItUp.Base.ViewModel.MainControls
             twitchCommands.Commands.Add(new EventCommandItemViewModel(EventTypeEnum.TwitchChannelResubscribed));
             twitchCommands.Commands.Add(new EventCommandItemViewModel(EventTypeEnum.TwitchChannelSubscriptionGifted));
             twitchCommands.Commands.Add(new EventCommandItemViewModel(EventTypeEnum.TwitchChannelMassSubscriptionsGifted));
+            twitchCommands.Commands.Add(new EventCommandItemViewModel(EventTypeEnum.TwitchChannelWatchStreak));
             twitchCommands.Commands.Add(new EventCommandItemViewModel(EventTypeEnum.TwitchChannelHighlightedMessage));
             twitchCommands.Commands.Add(new EventCommandItemViewModel(EventTypeEnum.TwitchChannelUserIntro));
             twitchCommands.Commands.Add(new EventCommandItemViewModel(EventTypeEnum.TwitchChannelPowerUpMessageEffect));

--- a/MixItUp.Base/ViewModel/Overlay/OverlayLeaderboardV3ViewModel.cs
+++ b/MixItUp.Base/ViewModel/Overlay/OverlayLeaderboardV3ViewModel.cs
@@ -68,6 +68,17 @@ namespace MixItUp.Base.ViewModel.Overlay
         }
         private int totalToShow;
 
+        public int RefreshTime
+        {
+            get { return this.refreshTime; }
+            set
+            {
+                this.refreshTime = value;
+                this.NotifyPropertyChanged();
+            }
+        }
+        private int refreshTime;
+
         public string BorderColor
         {
             get { return this.borderColor; }
@@ -152,6 +163,7 @@ namespace MixItUp.Base.ViewModel.Overlay
             this.BackgroundColor = "White";
 
             this.TotalToShow = 5;
+            this.RefreshTime = OverlayLeaderboardV3Model.DefaultRefreshTime;
 
             this.SelectedLeaderboardType = OverlayLeaderboardTypeV3Enum.ViewingTime;
 
@@ -172,6 +184,7 @@ namespace MixItUp.Base.ViewModel.Overlay
             this.BackgroundColor = item.BackgroundColor;
 
             this.TotalToShow = item.TotalToShow;
+            this.RefreshTime = (item.RefreshTime > 0) ? item.RefreshTime : OverlayLeaderboardV3Model.DefaultRefreshTime;
 
             this.SelectedLeaderboardType = item.LeaderboardType;
             if (this.SelectedLeaderboardType == OverlayLeaderboardTypeV3Enum.Consumable)
@@ -215,6 +228,11 @@ namespace MixItUp.Base.ViewModel.Overlay
 
         public override Result Validate()
         {
+            if (this.RefreshTime < 1)
+            {
+                return new Result(Resources.OverlayWidgetAValidRefreshTimeMustBeSpecified);
+            }
+
             if (this.SelectedLeaderboardType == OverlayLeaderboardTypeV3Enum.Consumable)
             {
                 if (this.SelectedConsumable == null)
@@ -236,6 +254,7 @@ namespace MixItUp.Base.ViewModel.Overlay
                 BackgroundColor = this.BackgroundColor,
 
                 TotalToShow = this.TotalToShow,
+                RefreshTime = (this.RefreshTime > 0) ? this.RefreshTime : OverlayLeaderboardV3Model.DefaultRefreshTime,
 
                 LeaderboardType = this.SelectedLeaderboardType,
                 TwitchBitsDataRange = this.SelectedTwitchBitsDataRange,

--- a/MixItUp.Base/ViewModel/Overlay/OverlayLeaderboardV3ViewModel.cs
+++ b/MixItUp.Base/ViewModel/Overlay/OverlayLeaderboardV3ViewModel.cs
@@ -68,16 +68,16 @@ namespace MixItUp.Base.ViewModel.Overlay
         }
         private int totalToShow;
 
-        public int RefreshTime
+        public int RefreshTimeSeconds
         {
-            get { return this.refreshTime; }
+            get { return this.refreshTimeSeconds; }
             set
             {
-                this.refreshTime = value;
+                this.refreshTimeSeconds = value;
                 this.NotifyPropertyChanged();
             }
         }
-        private int refreshTime;
+        private int refreshTimeSeconds;
 
         public string BorderColor
         {
@@ -163,7 +163,7 @@ namespace MixItUp.Base.ViewModel.Overlay
             this.BackgroundColor = "White";
 
             this.TotalToShow = 5;
-            this.RefreshTime = OverlayLeaderboardV3Model.DefaultRefreshTime;
+            this.RefreshTimeSeconds = OverlayLeaderboardV3Model.DefaultRefreshTimeSeconds;
 
             this.SelectedLeaderboardType = OverlayLeaderboardTypeV3Enum.ViewingTime;
 
@@ -184,7 +184,7 @@ namespace MixItUp.Base.ViewModel.Overlay
             this.BackgroundColor = item.BackgroundColor;
 
             this.TotalToShow = item.TotalToShow;
-            this.RefreshTime = (item.RefreshTime > 0) ? item.RefreshTime : OverlayLeaderboardV3Model.DefaultRefreshTime;
+            this.RefreshTimeSeconds = (item.RefreshTimeSeconds > 0) ? item.RefreshTimeSeconds : OverlayLeaderboardV3Model.DefaultRefreshTimeSeconds;
 
             this.SelectedLeaderboardType = item.LeaderboardType;
             if (this.SelectedLeaderboardType == OverlayLeaderboardTypeV3Enum.Consumable)
@@ -228,7 +228,7 @@ namespace MixItUp.Base.ViewModel.Overlay
 
         public override Result Validate()
         {
-            if (this.RefreshTime < 1)
+            if (this.RefreshTimeSeconds < 1)
             {
                 return new Result(Resources.OverlayWidgetAValidRefreshTimeMustBeSpecified);
             }
@@ -254,7 +254,7 @@ namespace MixItUp.Base.ViewModel.Overlay
                 BackgroundColor = this.BackgroundColor,
 
                 TotalToShow = this.TotalToShow,
-                RefreshTime = (this.RefreshTime > 0) ? this.RefreshTime : OverlayLeaderboardV3Model.DefaultRefreshTime,
+                RefreshTimeSeconds = (this.RefreshTimeSeconds > 0) ? this.RefreshTimeSeconds : OverlayLeaderboardV3Model.DefaultRefreshTimeSeconds,
 
                 LeaderboardType = this.SelectedLeaderboardType,
                 TwitchBitsDataRange = this.SelectedTwitchBitsDataRange,

--- a/MixItUp.Base/ViewModel/Overlay/OverlayPersistentTimerV3ViewModel.cs
+++ b/MixItUp.Base/ViewModel/Overlay/OverlayPersistentTimerV3ViewModel.cs
@@ -1,4 +1,4 @@
-﻿using MixItUp.Base.Model.Commands;
+using MixItUp.Base.Model.Commands;
 using MixItUp.Base.Model.Overlay;
 using MixItUp.Base.Model.Overlay.Widgets;
 using MixItUp.Base.Util;
@@ -168,6 +168,7 @@ namespace MixItUp.Base.ViewModel.Overlay
             OverlayPersistentTimerV3Model result = new OverlayPersistentTimerV3Model()
             {
                 InitialAmount = this.InitialAmount,
+                CurrentAmount = this.InitialAmount,
                 DisplayFormat = this.DisplayFormat,
                 MaxAmount = this.MaxAmount,
                 DisableOnCompletion = this.DisableOnCompletion,

--- a/MixItUp.Base/ViewModel/Overlay/OverlayWidgetV3ViewModel.cs
+++ b/MixItUp.Base/ViewModel/Overlay/OverlayWidgetV3ViewModel.cs
@@ -1,4 +1,4 @@
-﻿using MixItUp.Base.Model.Overlay;
+using MixItUp.Base.Model.Overlay;
 using MixItUp.Base.Model.Overlay.Widgets;
 using MixItUp.Base.Services;
 using MixItUp.Base.Util;
@@ -236,6 +236,8 @@ namespace MixItUp.Base.ViewModel.Overlay
 
         private bool isSaving = false;
 
+        private int existingPersistentTimerCurrentAmount;
+
         public OverlayWidgetV3ViewModel(OverlayItemV3Type type)
         {
             this.ID = Guid.NewGuid();
@@ -289,6 +291,11 @@ namespace MixItUp.Base.ViewModel.Overlay
         {
             this.existingWidget = widget;
             this.existingWidgetState = this.existingWidget.IsEnabled;
+
+            if (widget.Item is OverlayPersistentTimerV3Model existingPersistentTimer)
+            {
+                this.existingPersistentTimerCurrentAmount = existingPersistentTimer.CurrentAmount;
+            }
 
             this.ID = widget.ID;
             this.Type = widget.Item.Type;
@@ -385,6 +392,11 @@ namespace MixItUp.Base.ViewModel.Overlay
             item.DisplayOption = this.SelectedDisplayOption;
             this.Position.SetPosition(item);
 
+            if (this.existingWidget != null && item is OverlayPersistentTimerV3Model newTimer)
+            {
+                newTimer.CurrentAmount = this.existingPersistentTimerCurrentAmount;
+            }
+
             if (this.existingWidget == null)
             {
                 await item.Reset();
@@ -434,6 +446,10 @@ namespace MixItUp.Base.ViewModel.Overlay
 
             if (this.newWidget == null && this.existingWidget != null && this.existingWidgetState)
             {
+                if (this.existingWidget.Item is OverlayPersistentTimerV3Model existingPersistentTimer)
+                {
+                    existingPersistentTimer.CurrentAmount = this.existingPersistentTimerCurrentAmount;
+                }
                 await this.existingWidget.Enable();
             }
         }

--- a/MixItUp.Base/ViewModel/Settings/CommandsSettingsControlViewModel.cs
+++ b/MixItUp.Base/ViewModel/Settings/CommandsSettingsControlViewModel.cs
@@ -45,7 +45,7 @@ namespace MixItUp.Base.ViewModel.Settings
                 ChannelSession.Settings.DeleteChatCommandsWhenRun, (value) => { ChannelSession.Settings.DeleteChatCommandsWhenRun = value; });
             this.MassGiftedSubsFilterAmount = new GenericToggleNumberSettingsOptionControlViewModel(MixItUp.Base.Resources.MassGiftedSubsFilterAmount, ChannelSession.Settings.MassGiftedSubsFilterAmount,
                 (value) => { ChannelSession.Settings.MassGiftedSubsFilterAmount = value; }, MixItUp.Base.Resources.MassGiftedSubsFilterAmountTooltip);
-            this.UserEntranceCommandsOnlyWhenLive = new GenericToggleSettingsOptionControlViewModel(MixItUp.Base.Resources.IgnoreYourBotAccountForCommands,
+            this.UserEntranceCommandsOnlyWhenLive = new GenericToggleSettingsOptionControlViewModel(MixItUp.Base.Resources.UserEntranceCommandsOnlyWhenLive,
                 ChannelSession.Settings.UserEntranceCommandsOnlyWhenLive, (value) => { ChannelSession.Settings.UserEntranceCommandsOnlyWhenLive = value; });
             this.CommandLockSystem = new GenericComboBoxSettingsOptionControlViewModel<CommandServiceLockTypeEnum>(MixItUp.Base.Resources.CommandLockSystem, EnumHelper.GetEnumList<CommandServiceLockTypeEnum>(),
                 ChannelSession.Settings.CommandServiceLockType, (value) => { ChannelSession.Settings.CommandServiceLockType = value; }, MixItUp.Base.Resources.CommandLockSystemTooltip);

--- a/MixItUp.Reporter/Properties/AssemblyInfo.cs
+++ b/MixItUp.Reporter/Properties/AssemblyInfo.cs
@@ -53,5 +53,5 @@ using System.Windows;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.6.313.0")]
-[assembly: AssemblyFileVersion("1.6.313.0")]
+[assembly: AssemblyVersion("1.6.400.0")]
+[assembly: AssemblyFileVersion("1.6.400.0")]

--- a/MixItUp.SignalR.Client/MixItUp.SignalR.Client.csproj
+++ b/MixItUp.SignalR.Client/MixItUp.SignalR.Client.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
 	  <AssemblyTitle>MixItUp.SignalR.Client</AssemblyTitle>
-    <AssemblyVersion>1.6.313.0</AssemblyVersion>
-    <FileVersion>1.6.313.0</FileVersion>
+    <AssemblyVersion>1.6.400.0</AssemblyVersion>
+    <FileVersion>1.6.400.0</FileVersion>
 	  <Company>Blazing Cacti LLC</Company>
 	  <Copyright>Copyright © 2026 Blazing Cacti LLC, All Rights Reserved. </Copyright>
   </PropertyGroup>

--- a/MixItUp.WPF/Controls/Overlay/OverlayLeaderboardV3Control.xaml
+++ b/MixItUp.WPF/Controls/Overlay/OverlayLeaderboardV3Control.xaml
@@ -141,6 +141,8 @@
                 <ColumnDefinition Width="*" />
                 <ColumnDefinition Width="10" />
                 <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="10" />
+                <ColumnDefinition Width="180" />
             </Grid.ColumnDefinitions>
 
             <ComboBox Grid.Column="0" ItemsSource="{Binding LeaderboardTypes}" SelectedItem="{Binding SelectedLeaderboardType}" MaterialDesign:HintAssist.Hint="{x:Static resx:Resources.Type}" Style="{StaticResource MaterialDesignFloatingHintComboBox}">
@@ -160,6 +162,8 @@
                     </DataTemplate>
                 </ComboBox.ItemTemplate>
             </ComboBox>
+
+            <TextBox Grid.Column="4" Text="{Binding RefreshTime}" Width="150" MaterialDesign:HintAssist.Hint="{x:Static resx:Resources.RefreshTimeSecs}" Style="{StaticResource MaterialDesignFloatingHintTextBox}" />
         </Grid>
     </Grid>
 </Controls:LoadingControlBase>

--- a/MixItUp.WPF/Controls/Overlay/OverlayLeaderboardV3Control.xaml
+++ b/MixItUp.WPF/Controls/Overlay/OverlayLeaderboardV3Control.xaml
@@ -163,7 +163,7 @@
                 </ComboBox.ItemTemplate>
             </ComboBox>
 
-            <TextBox Grid.Column="4" Text="{Binding RefreshTime}" Width="150" MaterialDesign:HintAssist.Hint="{x:Static resx:Resources.RefreshTimeSecs}" Style="{StaticResource MaterialDesignFloatingHintTextBox}" />
+            <TextBox Grid.Column="4" Text="{Binding RefreshTimeSeconds}" Width="150" MaterialDesign:HintAssist.Hint="{x:Static resx:Resources.RefreshTimeSecs}" Style="{StaticResource MaterialDesignFloatingHintTextBox}" />
         </Grid>
     </Grid>
 </Controls:LoadingControlBase>

--- a/MixItUp.WPF/Controls/Settings/CommandsSettingsControl.xaml
+++ b/MixItUp.WPF/Controls/Settings/CommandsSettingsControl.xaml
@@ -12,6 +12,7 @@
              d:DesignHeight="450" d:DesignWidth="800">
     <Grid Margin="20">
         <StackPanel>
+            <GenericSettingsControls:GenericToggleSettingsOptionControl DataContext="{Binding UserEntranceCommandsOnlyWhenLive}" />
             <GenericSettingsControls:GenericToggleSettingsOptionControl DataContext="{Binding AllowCommandWhispering}" />
             <GenericSettingsControls:GenericToggleSettingsOptionControl DataContext="{Binding IgnoreBotAccount}" />
             <GenericSettingsControls:GenericToggleSettingsOptionControl DataContext="{Binding DeleteChatCommandsWhenRun}" />

--- a/MixItUp.WPF/MixItUp.WPF.csproj
+++ b/MixItUp.WPF/MixItUp.WPF.csproj
@@ -9,8 +9,8 @@
     <AssemblyTitle>MixItUp.Client</AssemblyTitle>
     <Company>Blazing Cacti LLC</Company>
 		<Copyright>Copyright © 2026 Blazing Cacti LLC, All Rights Reserved.</Copyright>
-    <AssemblyVersion>1.6.313.0</AssemblyVersion>
-    <FileVersion>1.6.313.0</FileVersion>
+    <AssemblyVersion>1.6.400.0</AssemblyVersion>
+    <FileVersion>1.6.400.0</FileVersion>
 		<Version>1.6.0</Version>
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <PublishUrl>publish\</PublishUrl>

--- a/MixItUp.WPF/Properties/AssemblyInfo.cs
+++ b/MixItUp.WPF/Properties/AssemblyInfo.cs
@@ -50,5 +50,5 @@ using System.Windows;
 //
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("1.6.313.0")]
-[assembly: AssemblyFileVersion("1.6.313.0")]
+[assembly: AssemblyVersion("1.6.400.0")]
+[assembly: AssemblyFileVersion("1.6.400.0")]

--- a/MixItUp.WPF/UpdateWindow.xaml
+++ b/MixItUp.WPF/UpdateWindow.xaml
@@ -53,50 +53,64 @@
                         Click="CloseButton_Click"
                         Style="{StaticResource MaterialDesignIconButton}"
                         ToolTip="{x:Static resx:Resources.Close}">
-                        <MaterialDesign:PackIcon Width="20" Height="20" Kind="Close" />
+                        <MaterialDesign:PackIcon
+                            Width="20"
+                            Height="20"
+                            Kind="Close" />
                     </Button>
 
-                    <StackPanel
+                    <Grid
                         x:Name="MandatoryBanner"
                         Grid.Row="1"
+                        MaxWidth="600"
                         Margin="0,0,0,15"
                         HorizontalAlignment="Center"
-                        Orientation="Horizontal"
                         Visibility="Collapsed">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
                         <MaterialDesign:PackIcon
-                            Width="20" Height="20"
+                            Grid.Column="0"
+                            Width="20"
+                            Height="20"
                             Margin="0,0,8,0"
                             VerticalAlignment="Center"
                             Foreground="{DynamicResource MaterialDesign.Brush.Primary}"
                             Kind="AlertCircle" />
                         <TextBlock
+                            Grid.Column="1"
                             VerticalAlignment="Center"
                             FontWeight="SemiBold"
-                            Text="{x:Static resx:Resources.ThisUpdateIsRequired}" />
-                    </StackPanel>
+                            Text="{x:Static resx:Resources.ThisUpdateIsRequired}"
+                            TextAlignment="Center"
+                            TextWrapping="Wrap" />
+                    </Grid>
 
-                    <StackPanel
+                    <Grid
                         Grid.Row="2"
+                        MaxWidth="600"
                         Margin="0,0,0,15"
-                        HorizontalAlignment="Center"
-                        Orientation="Horizontal">
+                        HorizontalAlignment="Center">
                         <TextBlock
                             VerticalAlignment="Center"
                             FontSize="22"
                             FontWeight="SemiBold"
-                            Text="{x:Static resx:Resources.ANewUpdateIsAvailableForMixItUp}" />
-                    </StackPanel>
+                            Text="{x:Static resx:Resources.ANewUpdateIsAvailableForMixItUp}"
+                            TextAlignment="Center"
+                            TextWrapping="Wrap" />
+                    </Grid>
 
-                    <StackPanel
+                    <WrapPanel
                         Grid.Row="3"
                         Margin="0,0,0,15"
                         HorizontalAlignment="Center"
                         Orientation="Horizontal">
                         <Border
+                            Padding="12,6"
                             BorderBrush="{DynamicResource MaterialDesignDivider}"
                             BorderThickness="1"
-                            CornerRadius="6"
-                            Padding="12,6">
+                            CornerRadius="6">
                             <StackPanel Orientation="Horizontal">
                                 <TextBlock
                                     VerticalAlignment="Center"
@@ -110,15 +124,16 @@
                             </StackPanel>
                         </Border>
                         <MaterialDesign:PackIcon
-                            Width="24" Height="24"
+                            Width="24"
+                            Height="24"
                             Margin="12,0"
                             VerticalAlignment="Center"
                             Foreground="{DynamicResource MaterialDesign.Brush.Primary}"
                             Kind="ArrowRight" />
                         <Border
+                            Padding="12,6"
                             Background="{DynamicResource MaterialDesign.Brush.Primary}"
-                            CornerRadius="6"
-                            Padding="12,6">
+                            CornerRadius="6">
                             <StackPanel Orientation="Horizontal">
                                 <TextBlock
                                     VerticalAlignment="Center"
@@ -132,7 +147,7 @@
                                     Foreground="White" />
                             </StackPanel>
                         </Border>
-                    </StackPanel>
+                    </WrapPanel>
 
                     <Border
                         x:Name="PreviewUpdateGrid"
@@ -144,17 +159,24 @@
                         CornerRadius="8"
                         Visibility="Collapsed">
                         <StackPanel>
-                            <StackPanel Orientation="Horizontal">
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="*" />
+                                </Grid.ColumnDefinitions>
                                 <MaterialDesign:PackIcon
-                                    Width="20" Height="20"
+                                    Grid.Column="0"
+                                    Width="20"
+                                    Height="20"
                                     Margin="0,0,8,0"
                                     VerticalAlignment="Top"
                                     Foreground="{DynamicResource MaterialDesign.Brush.Primary}"
                                     Kind="AlertOutline" />
                                 <TextBlock
+                                    Grid.Column="1"
                                     Text="{x:Static resx:Resources.PreviewUpdateWarning1}"
                                     TextWrapping="Wrap" />
-                            </StackPanel>
+                            </Grid>
                             <TextBlock
                                 Margin="28,6,0,0"
                                 Text="{x:Static resx:Resources.PreviewUpdateWarning2}"
@@ -200,10 +222,10 @@
                     <TextBlock
                         Grid.Row="8"
                         Margin="0,15,0,15"
-                        HorizontalAlignment="Center"
                         FontSize="12"
                         Opacity="0.6"
                         Text="{x:Static resx:Resources.IfUpdateDoesNotCompleteRestartComputer}"
+                        TextAlignment="Center"
                         TextWrapping="Wrap" />
 
                     <Controls:LoadingStatusBar


### PR DESCRIPTION
- [MAINT] Update OBS Studio WebSocket V5 connections and stabilize reconnection logic *
- [MAINT] Update Stream Elements service to new WebSocket server and remove deprecated Stream Elements Merch event **
- [MAINT] Improve performance when opening commands with a large number of actions
- [MAINT] Upgrade local authentication and overlay servers to Kestrel-based servers
- [MAINT] Harden Stream Elements WebSocket reconnection and subscription flows
- [MAINT] Improve WebSocket connections for various services
- [MAINT] Update MIU Installer error logging and shortcut creation

- [FEAT] Add Twitch Watch Streak event (supports $userwatchstreak and $watchstreakchannelpointsawarded)
- [FEAT] Add new option Settings -> Commands to run Entrance Commands only when live
- [FEAT] Add custom code editor for script action and overlay HTML/CSS/JS tabs in widgets and overlay actions
- [FEAT] Add $twitchclipduration clip duration special identifier for Twitch clips playback in Overlay action
- [FEAT] Add Years and Months to dateto() and datefrom() functions in special identifier action
- [FEAT] Update branding in various places
- [FEAT] Add Export Data button to inventory window
- [FEAT] Add save source screenshot option to Streaming Software action (OBS Studio only)
- [FEAT] Add delete all quotes button
- [FEAT] Add custom refresh rate for leaderboard overlay widgets
- [FEAT] Add reset button for persistent timer and persist timer amount between widget saves
- [FEAT] Include user-only chat commands in the !commands pre-made command

- [FIX] YouTube mass gifted memberships goal overlay and bonus currency
- [FIX] Harden settings persistence to prevent settings loss in the case of a crash or power failure during a save operation
- [FIX] Fix bug with Patreon account linking and losing subscriber status
- [FIX] Fix crash when trying to edit Lumia Stream actions
- [FIX] Add support for custom content-type and remove pre-made headers in Web Request Action
- [FIX] Show full app history in changelog page
- [FIX] Streamlabs Desktop minor fix for Y Scale typo
- [FIX] Twitch gigantified emote $emoteurl
- [FIX] Streamlabs Desktop source visibility fixed for dual output scenes
- [FIX] Crashes when receiving mass gifted subs, and fix total gifted tracking
- [FIX] Minor UI fixes across the application
- [FIX] Persistent timer showing 0:00 when editing

> **\* Legacy OBS WebSocket support (< v5.0) removed**  
> **\*\* Test donations from SE Dashboard/Activity feed no longer triggers MIU SE Donation event**