### PR TITLE
feat(youtube): send command replies only to the stream where the command was used

### DIFF
--- a/MixItUp.Base/Services/ChatService.cs
+++ b/MixItUp.Base/Services/ChatService.cs
@@ -9,6 +9,7 @@ using MixItUp.Base.Services.Twitch.New;
 using MixItUp.Base.Services.YouTube.New;
 using MixItUp.Base.Util;
 using MixItUp.Base.ViewModel.Chat;
+using MixItUp.Base.ViewModel.Chat.YouTube;
 using MixItUp.Base.ViewModel.User;
 using System;
 using System.Collections.Generic;
@@ -149,7 +150,17 @@ namespace MixItUp.Base.Services
                     }
                     else if (platform == StreamingPlatformTypeEnum.YouTube && ServiceManager.Get<YouTubeSession>().IsConnected)
                     {
-                        await ServiceManager.Get<YouTubeSession>().SendMessage(message, sendAsStreamer);
+                        if (!string.IsNullOrEmpty(replyMessageID) &&
+                            this.messagesLookup.TryGetValue(replyMessageID, out ChatMessageViewModel replyMessage) &&
+                            replyMessage is YouTubeChatMessageViewModel youTubeReplyMessage &&
+                            !string.IsNullOrEmpty(youTubeReplyMessage.BroadcastID))
+                        {
+                            await ServiceManager.Get<YouTubeSession>().SendMessage(message, youTubeReplyMessage.BroadcastID, sendAsStreamer);
+                        }
+                        else
+                        {
+                            await ServiceManager.Get<YouTubeSession>().SendMessage(message, sendAsStreamer);
+                        }
                     }
                     else if (platform == StreamingPlatformTypeEnum.Trovo && ServiceManager.Get<TrovoSession>().IsConnected)
                     {

--- a/MixItUp.Base/Services/YouTube/New/YouTubeSession.cs
+++ b/MixItUp.Base/Services/YouTube/New/YouTubeSession.cs
@@ -284,11 +284,25 @@ namespace MixItUp.Base.Services.YouTube.New
 
         public override async Task SendMessage(string message, bool sendAsStreamer = false)
         {
+            await this.SendMessageInternal(message, sendAsStreamer);
+        }
+
+        public async Task SendMessage(string message, string broadcastID, bool sendAsStreamer = false)
+        {
+            await this.SendMessageInternal(message, sendAsStreamer, broadcastID);
+        }
+
+        private async Task SendMessageInternal(string message, bool sendAsStreamer = false, string broadcastID = null)
+        {
+            LiveBroadcast targetedBroadcast = null;
+            bool hasTargetedBroadcast = !string.IsNullOrEmpty(broadcastID) && this.LiveBroadcasts.TryGetValue(broadcastID, out targetedBroadcast);
+
             List<LiveChatMessage> messagesToProcess = new List<LiveChatMessage>();
             foreach (string m in this.SplitLargeMessage(message))
             {
                 bool processedMessage = false;
-                foreach (LiveBroadcast broadcast in this.LiveBroadcasts.Values.ToList())
+                IEnumerable<LiveBroadcast> broadcasts = hasTargetedBroadcast ? new List<LiveBroadcast>() { targetedBroadcast } : this.LiveBroadcasts.Values.ToList();
+                foreach (LiveBroadcast broadcast in broadcasts)
                 {
                     LiveChatMessage resultMessage = null;
                     if (sendAsStreamer || !this.IsBotConnected)
@@ -339,7 +353,7 @@ namespace MixItUp.Base.Services.YouTube.New
 
             foreach (LiveChatMessage messageToProcess in messagesToProcess)
             {
-                await this.ProcessMessage(messageToProcess);
+                await this.ProcessMessage(messageToProcess, hasTargetedBroadcast ? broadcastID : null);
             }
         }
 
@@ -515,7 +529,7 @@ namespace MixItUp.Base.Services.YouTube.New
                                         {
                                             if (!messageIDsToIgnore.Contains(message.Id))
                                             {
-                                                await this.ProcessMessage(message);
+                                                await this.ProcessMessage(message, broadcast.Id);
                                             }
                                         }
 
@@ -547,7 +561,7 @@ namespace MixItUp.Base.Services.YouTube.New
             }
         }
 
-        private async Task ProcessMessage(LiveChatMessage liveChatMessage)
+        private async Task ProcessMessage(LiveChatMessage liveChatMessage, string broadcastID = null)
         {
             try
             {
@@ -571,7 +585,7 @@ namespace MixItUp.Base.Services.YouTube.New
                     {
                         if (liveChatMessage.Snippet.HasDisplayContent.GetValueOrDefault() && !string.IsNullOrEmpty(liveChatMessage.Snippet.DisplayMessage))
                         {
-                            await ServiceManager.Get<ChatService>().AddMessage(new YouTubeChatMessageViewModel(liveChatMessage, user));
+                            await ServiceManager.Get<ChatService>().AddMessage(new YouTubeChatMessageViewModel(liveChatMessage, user, broadcastID));
                         }
                     }
                     else if (NewMemberEventMessageType.Equals(liveChatMessage.Snippet.Type))

--- a/MixItUp.Base/ViewModel/Chat/YouTube/YouTubeChatMessageViewModel.cs
+++ b/MixItUp.Base/ViewModel/Chat/YouTube/YouTubeChatMessageViewModel.cs
@@ -10,6 +10,8 @@ namespace MixItUp.Base.ViewModel.Chat.YouTube
 {
     public class YouTubeChatMessageViewModel : UserChatMessageViewModel
     {
+        public string BroadcastID { get; private set; }
+
         // YouTube Emojis:
         // https://emojipedia.org/youtube/
         // https://emojis.wiki/youtube/
@@ -17,9 +19,10 @@ namespace MixItUp.Base.ViewModel.Chat.YouTube
         // 
         // https://www.gstatic.com/youtube/img/emojis/emojis-svg-5.json
 
-        public YouTubeChatMessageViewModel(LiveChatMessage message, UserV2ViewModel user = null)
+        public YouTubeChatMessageViewModel(LiveChatMessage message, UserV2ViewModel user = null, string broadcastID = null)
             : base(message.Id, StreamingPlatformTypeEnum.YouTube, user)
         {
+            this.BroadcastID = broadcastID;
             this.ProcessMessageContents(message.Snippet.DisplayMessage);
         }
 


### PR DESCRIPTION
Adjust handling of YT Chat messages and send messages to the broadcast where the command originated from. 

Command responses now stay in the stream where the viewer triggered them, instead of showing up in every active YouTube stream. Existing behavior for timers and other legacy workflows remains as is